### PR TITLE
v0.2.13 - Added cache mechanism(+fixed) and added drift scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,51 @@
 # Changelog
 
-## 0.2.12 - Current
+## 0.2.13 - Current
 
 ### Added
+- Added scripts/backup-db.sh for gzip-compressed pg_dump backups with auto-parsed DATABASE_URL.
+- Added scripts/restore-db.sh for confirmed drop-and-restore with connection termination.
+- Added scripts/test-db-backup-restore.sh smoke test validating the full backup/restore cycle.
+- Added .InternalDocs/db-backup-restore-runbook.md covering all recovery scenarios.
+- **Drift** - Added `POST /api/admin/drift/{event_id}/fix` and `POST /api/admin/drift/fix-all` to immediately reconcile auto-fixable drift events without waiting for the next scan.
+- **Drift UI** - Added per-row Fix and toolbar Fix All buttons to the Admin > Drift tab; events expose an `auto_fixable` flag so the UI can disable buttons for non-fixable types.
+- **Backups** - Added 15-second Redis cache for snapshot listings with invalidation on create, rollback, and delete to cut PVE round-trips on the backup pages.
+- **Proxmox cache helpers** - Added `app/services/proxmox_cache.py` with reusable cached PVE call primitives shared across routers.
+
+### Changed
+- **Drift scanner** - `status_mismatch` and `node_mismatch` are now auto-corrected against PVE during the scheduled scan (PVE is treated as source of truth); these no longer raise drift events.
+- **Network migration** - Rewrote `PUT /api/compute/vms/{id}/network` to be transactionally consistent: target VPC IP is allocated first, the instance is stopped, PVE config is updated atomically (single call for VMs with cloud-init regen, single call for LXC), then DB is committed and the instance restarted; on any failure the previous PVE config and DB state are restored. Restricted to `net0` so primary-VPC reservation logic stays coherent.
+- **Backups** - All snapshot operations (list, create, rollback, delete) now run via `asyncio.to_thread` so the event loop is no longer blocked on PVE API calls.
+- **Celery tasks** - `email_tasks`, `resource_lifecycle`, and `drift_scanner` now run their async bodies through a shared `app/tasks/_async_runner.py` helper that builds a fresh per-task engine; eliminates the recurring "Future attached to a different loop" errors under Celery prefork.
+- **Cluster status cache** - `refresh_cluster_status_cache` now refreshes a single primary key instead of iterating registered clusters, matching the single-cluster deployment model.
+
+### Fixed
+- **IP reservations** - Network migration no longer drops the old reservation before confirming the target VPC has an allocatable IP; returns 409 if no IP is available, preventing the "DB has no IP, PVE keeps stale ipconfig0" drift.
+- **Secondary NIC reservations** - Old IP reservation cleanup is now scoped to the old VPC subnets and the primary NIC label, so secondary-NIC reservations are no longer wiped during a primary network change.
+
+
+## 0.2.12 - 2026-04-21
+
+### Added
+- Added RequestIDMiddleware to assign X-Request-ID to every request and response.
+- Added Prometheus /metrics endpoint via prometheus-fastapi-instrumentator.
+- Added typed cpu_cores, ram_mb, disk_gb, spec_hostname properties to Resource model.
+- Moved instance type seeds to backend/seeds/instance_types.yml for operator customization.
+- Added PAWS-ID machine-parseable stamp to Proxmox resource description on create.
+- Added drift_events table and Alembic migration b1c2d3e4f5a6.
+- Added paws.scan_drift Celery task scheduled every 5 minutes to detect DB/cluster divergence.
+- Added /api/admin/drift endpoints for listing and acknowledging drift events.
+- Added Drift tab to Admin > Infrastructure panel.
 - **Redis-backed cache for cluster status** - `/api/cluster/status` now caches the sanitized Proxmox response in Redis with a 10s TTL, eliminating per-request PVE API round-trips on dashboard load; new `app/services/cache.py` helper provides reusable JSON cache primitives that gracefully no-op when Redis is unavailable
 - **Redis-backed cache for live VM and container status** - `list_vms`, `get_vm`, `list_containers`, `get_container` now cache per-resource live status in Redis with a 5s TTL; cache is invalidated on power actions (start/stop/shutdown/suspend/hibernate) and resize so user-triggered changes surface immediately
 - **Celery Beat cache warming** - New `paws.refresh_cluster_status_cache` task runs every 30 seconds to pre-populate cluster status for every registered cluster so the dashboard always reads from a warm cache
 - **`cached_at` timestamps on cluster status** - `ClusterStatusResponse` now carries an epoch-second `cached_at` field so the UI can render freshness
+
+### Changed
+- Simplified cluster status cache to use a single key for single-cluster deployments.
+- Auto-resolved cluster_id from registry on resource, VPC, and security group creation.
+- Removed cluster selector UI from instance creation, VPC, and security group forms.
+- Dropped stale cluster_id query params from admin cluster status and task log fetch calls.
 
 ## 0.2.11 - 2026-04-09
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,28 @@ cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 export PAWS_SECRET_KEY=dev-secret-key
+export PAWS_MASTER_KEY=$(python -c 'import base64,os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())')
 alembic upgrade head
-uvicorn app.main:app --reload --port 8000
+python -m uvicorn app.main:app --reload --port 8000
 
-# 5. Frontend
+# 5. Celery worker + beat (separate terminals; many features depend on them)
+cd backend && source .venv/bin/activate
+set -a && source ../.env && set +a
+python -m celery -A app.worker.celery_app worker --loglevel=info
+# In a third terminal:
+python -m celery -A app.worker.celery_app beat --scheduler redbeat.RedBeatScheduler --loglevel=info
+
+# 6. Frontend
 cd ../frontend
 npm install && npm run dev
+
+# 7. First-run admin
+# Open http://localhost:8000/setup to create the initial admin account.
 ```
+
+`PAWS_MASTER_KEY` must be stable across restarts - if it changes, all
+encrypted DB credentials (cluster connections, SMTP, OAuth secrets) become
+unreadable. Persist it to `.env`.
 
 ## Project Layout
 
@@ -47,7 +62,10 @@ New routers -> register in `main.py`. New pages -> add route in `App.tsx`. New m
 **Frontend:** TypeScript only. Functional components with hooks. All API calls through `api/client.ts`. Avoid `any`.
 
 ```bash
-# Check before committing
+# Check before committing - mirrors CI exactly
+./scripts/ci-local.sh
+
+# Or run pieces individually:
 cd backend && ruff check app/ tests/ && ruff format --check app/ tests/
 cd frontend && npm run lint && npx tsc --noEmit
 ```
@@ -70,5 +88,14 @@ Test fixtures in `conftest.py`: `client`, `auth_client`, `admin_client`, `mock_p
 - Keep changes small and focused
 - Include tests for new endpoints
 - Add new env vars to `.env.example`
+- Update `CHANGELOG.md` under `## Unreleased` (or the current version) following [Keep a Changelog](https://keepachangelog.com/) format
 - Never commit secrets or `.env` files
-- All CI checks must pass
+- All CI checks must pass (run `./scripts/ci-local.sh` first)
+
+## Conventions
+
+See [`.InternalDocs/rules-of-engagement.md`](.InternalDocs/rules-of-engagement.md) for the full standards covering:
+
+- ASCII-only character encoding (no smart quotes, em-dashes, emoji)
+- Changelog entry format and grouping
+- Issue labels, sizing, and structure

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![CI](https://github.com/coelacant1/Proxmox-Automated-Web-Services/actions/workflows/ci.yml/badge.svg)](https://github.com/coelacant1/Proxmox-Automated-Web-Services/actions/workflows/ci.yml)
 
-A self-hosted, AWS-like infrastructure platform built on Proxmox VE. Provides multi-tenant compute, networking, storage, backups, monitoring, and billing through a web UI and REST API.
+A self-hosted, AWS-like infrastructure platform built on Proxmox VE. Provides multi-tenant compute, networking, storage, backups, and monitoring through a web UI and REST API.
 
 > [!WARNING]
-> This is heavily work-in-progress and no where near usable. I am just working through building the user interface as well as working out features one-by-one as I link them to the UI.
+> This is heavily work-in-progress and not usable. Currently, all features work except for Networking finalization/Endpoints/Firewall. I am just working through building the user interface as well as working out features one-by-one as I link them to the UI.
 
 ![Dashboard](assets/ui_example1.png)
 
@@ -16,7 +16,6 @@ A self-hosted, AWS-like infrastructure platform built on Proxmox VE. Provides mu
 - **Storage** - S3-compatible object storage (Ceph RadosGW) with file browser, sharing, presigned URLs
 - **Backups** - PBS integration, scheduled plans, point-in-time restore
 - **Monitoring** - Per-resource metrics, alarms, log aggregation
-- **Billing** - Virtual credits, per-resource cost tracking, usage dashboards
 - **Auth** - Local accounts (JWT) + OAuth2/OIDC, RBAC (Admin/Operator/Member/Viewer)
 - **Admin** - User management, template catalog, quotas, audit logging
 
@@ -25,7 +24,7 @@ A self-hosted, AWS-like infrastructure platform built on Proxmox VE. Provides mu
 | Layer | Technology |
 |-------|-----------|
 | Frontend | React 19, TypeScript, Vite, Tailwind CSS v4 |
-| Backend | Python 3.12+, FastAPI, SQLAlchemy 2 (async), Pydantic v2 |
+| Backend | Python 3.11+, FastAPI, SQLAlchemy 2 (async), Pydantic v2 |
 | Database | PostgreSQL 16 |
 | Cache/Queue | Redis 7, Celery |
 | Storage | Ceph RadosGW, Proxmox Backup Server |
@@ -37,7 +36,7 @@ A self-hosted, AWS-like infrastructure platform built on Proxmox VE. Provides mu
 # 1. Clone and configure
 git clone https://github.com/coelacant1/Proxmox-Automated-Web-Services.git
 cd Proxmox-Automated-Web-Services
-cp .env.example .env    # edit with your Proxmox host, token, secret key
+cp .env.example .env    # set PAWS_SECRET_KEY (required); see "Environment Variables"
 
 # 2. Start everything
 docker compose up -d
@@ -45,8 +44,13 @@ docker compose up -d
 # 3. Run migrations
 docker compose exec backend alembic upgrade head
 
-# 4. Get admin password (generated on first run)
-docker compose logs backend | grep "admin account"
+# 4. Create the initial admin account
+#    Open http://localhost:8000/setup in a browser and follow the wizard.
+#    (Fallback: if you skip the wizard, an admin password is auto-generated on
+#    first boot - find it with: docker compose logs backend | grep "admin account")
+
+# 5. Add your Proxmox cluster via the UI
+#    Admin > Infrastructure > Connections (PVE token + optional PBS/S3 creds)
 ```
 
 **Access:**
@@ -61,22 +65,66 @@ API docs at `http://localhost:8000/docs`, `http://localhost:8000/redoc`, and `ht
 
 ## Local Development
 
+Run Postgres and Redis in Docker, the backend / Celery / frontend on the host
+for fast reloads.
+
 ```bash
-# Data services
+# 1. Data services (Postgres + Redis)
 sudo docker compose up -d db redis
 
-# Backend
+# 2. Environment - generate keys once and persist them in .env
+cp .env.example .env
+echo "PAWS_SECRET_KEY=$(openssl rand -hex 32)" >> .env
+echo "PAWS_MASTER_KEY=$(python -c 'import base64,os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())')" >> .env
+# Point the backend at the dockerized DB/Redis on localhost:
+echo "PAWS_DATABASE_URL=postgresql+asyncpg://paws:paws@localhost:5432/paws" >> .env
+echo "PAWS_REDIS_URL=redis://localhost:6379/0" >> .env
+
+# 3. Backend (FastAPI)
 cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-export PAWS_SECRET_KEY=dev-secret-key
 alembic upgrade head
-uvicorn app.main:app --reload --port 8000
+# Load .env into the shell, then run uvicorn:
+set -a && source ../.env && set +a
+python -m uvicorn app.main:app --reload --port 8000
 
-# Frontend (separate terminal)
+# 4. Celery worker + beat (separate terminals, same venv & .env)
+cd backend
+source .venv/bin/activate              # if you made the venv
+set -a && source ../.env && set +a
+python -m celery -A app.worker.celery_app worker --loglevel=info
+
+cd backend
+source .venv/bin/activate              # if you made the venv
+set -a && source ../.env && set +a
+python -m celery -A app.worker.celery_app beat --scheduler redbeat.RedBeatScheduler --loglevel=info
+
+# 5. Frontend (separate terminal)
 cd frontend
-npm install && npm run dev
+npm install && npm run dev   # http://localhost:5173, proxies API calls to :8000
 ```
+
+### First-run setup
+
+1. Open `http://localhost:8000/setup` once to create the initial admin account
+   (or grab the auto-generated password from the backend logs).
+2. Sign in to the UI (`http://localhost:5173`) and go to
+   **Admin > Infrastructure > Connections** to add your Proxmox cluster
+   (PVE host + API token; optional PBS / S3). Credentials are AES-256-GCM
+   encrypted at rest with `PAWS_MASTER_KEY`.
+
+### Notes
+
+- **Run Celery locally too.** Beat warms hot Proxmox caches every ~10s; without
+  it, list pages (VMs, LXCs, Resources) hit Proxmox cold and feel slow.
+- **`PAWS_MASTER_KEY` must be stable.** If it changes, all encrypted DB
+  credentials become unreadable and connections must be re-added. Keep the
+  same value in `.env` for both the host backend and any docker compose runs.
+- **`uvicorn` not on PATH?** Use `python -m uvicorn ...` from inside the venv.
+- **Skip Docker for backend hot-reload.** Keep `db` + `redis` in compose; run
+  `backend` / `celery-worker` / `celery-beat` on the host so code edits reload
+  instantly without a rebuild.
 
 ## Testing
 
@@ -88,16 +136,19 @@ cd frontend && npx tsc --noEmit     # type-check
 
 ## Environment Variables
 
-All use the `PAWS_` prefix. See `.env.example` for the full list. Key ones:
+All use the `PAWS_` prefix. See `.env.example` for the full list. Proxmox /
+PBS / S3 connections are **not** in `.env` - add them via
+**Admin > Infrastructure > Connections** (encrypted in the database).
 
 | Variable | Description |
 |----------|-------------|
-| `PAWS_SECRET_KEY` | JWT signing key (required) |
-| `PAWS_PROXMOX_HOST` | Proxmox API hostname |
-| `PAWS_PROXMOX_TOKEN_ID` | Proxmox API token ID |
-| `PAWS_PROXMOX_TOKEN_SECRET` | Proxmox API token secret |
-| `PAWS_DATABASE_URL` | PostgreSQL connection string |
-| `PAWS_REDIS_URL` | Redis connection string |
+| `PAWS_SECRET_KEY` | JWT signing key (required; generate with `openssl rand -hex 32`) |
+| `PAWS_MASTER_KEY` | AES-256-GCM key for encrypting DB-stored secrets (auto-generated on first run if unset; persist it to keep cluster credentials readable across restarts) |
+| `PAWS_DATABASE_URL` | PostgreSQL connection string (e.g. `postgresql+asyncpg://paws:paws@localhost:5432/paws`) |
+| `PAWS_REDIS_URL` | Redis connection string (e.g. `redis://localhost:6379/0`) |
+| `PAWS_LOCAL_AUTH_ENABLED` | Allow username/password accounts |
+| `PAWS_OAUTH_ENABLED` | Enable OIDC SSO (Authentik etc.) |
+| `PAWS_CORS_ORIGINS` | Comma-separated list of allowed UI origins |
 
 ## Contributing
 

--- a/backend/alembic/versions/1a2b3c4d5e6f_fix_cluster_connections_id_to_uuid.py
+++ b/backend/alembic/versions/1a2b3c4d5e6f_fix_cluster_connections_id_to_uuid.py
@@ -1,0 +1,32 @@
+"""Fix cluster_connections.id column type from CHAR to UUID.
+
+Revision ID: 1a2b3c4d5e6f
+Revises: f6a7b8c9d0e1, a1b2c3d4e5f7
+Create Date: 2026-04-21
+
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "1a2b3c4d5e6f"
+down_revision = ("f6a7b8c9d0e1", "a1b2c3d4e5f7")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        text(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_name = 'cluster_connections' AND column_name = 'id'"
+        )
+    )
+    col_type = result.scalar()
+    if col_type and col_type.lower() != "uuid":
+        op.execute(text("ALTER TABLE cluster_connections ALTER COLUMN id TYPE uuid USING id::uuid"))
+
+
+def downgrade() -> None:
+    op.execute(text("ALTER TABLE cluster_connections ALTER COLUMN id TYPE character(36) USING id::text"))

--- a/backend/alembic/versions/b1c2d3e4f5a6_add_drift_events_table.py
+++ b/backend/alembic/versions/b1c2d3e4f5a6_add_drift_events_table.py
@@ -1,0 +1,49 @@
+"""Add drift_events table.
+
+Revision ID: b1c2d3e4f5a6
+Revises: 1a2b3c4d5e6f
+Create Date: 2026-04-21
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+revision = "b1c2d3e4f5a6"
+down_revision = "1a2b3c4d5e6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "drift_events",
+        sa.Column("id", PG_UUID(as_uuid=False), primary_key=True),
+        sa.Column("detected_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column(
+            "resource_id", PG_UUID(as_uuid=False), sa.ForeignKey("resources.id", ondelete="SET NULL"), nullable=True
+        ),
+        sa.Column("proxmox_vmid", sa.Integer, nullable=True),
+        sa.Column("proxmox_node", sa.String(100), nullable=True),
+        sa.Column("drift_type", sa.String(50), nullable=False),
+        sa.Column("details", sa.Text, nullable=True),
+        sa.Column("acknowledged", sa.Boolean, default=False, nullable=False),
+        sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "acknowledged_by", PG_UUID(as_uuid=False), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+        ),
+    )
+    op.create_index("ix_drift_events_detected_at", "drift_events", ["detected_at"])
+    op.create_index("ix_drift_events_resource_id", "drift_events", ["resource_id"])
+    op.create_index("ix_drift_events_drift_type", "drift_events", ["drift_type"])
+    op.create_index("ix_drift_events_acknowledged", "drift_events", ["acknowledged"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_drift_events_acknowledged", "drift_events")
+    op.drop_index("ix_drift_events_drift_type", "drift_events")
+    op.drop_index("ix_drift_events_resource_id", "drift_events")
+    op.drop_index("ix_drift_events_detected_at", "drift_events")
+    op.drop_table("drift_events")

--- a/backend/alembic/versions/f6a7b8c9d0e1_add_cluster_connections_and_encrypted.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_add_cluster_connections_and_encrypted.py
@@ -18,7 +18,8 @@ def upgrade() -> None:
     # --- cluster_connections table ---
     op.create_table(
         "cluster_connections",
-        sa.Column("id", sa.CHAR(36), primary_key=True),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
         sa.Column("name", sa.String(100), nullable=False, unique=True),
         sa.Column("conn_type", sa.String(20), nullable=False),
         sa.Column("host", sa.String(255), nullable=False),

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,5 +1,6 @@
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.pool import NullPool
 
 from app.core.config import settings
 
@@ -17,3 +18,18 @@ async def get_db() -> AsyncSession:
             yield session
         finally:
             await session.close()
+
+
+def make_task_session_factory():
+    """Build an async sessionmaker bound to a brand-new engine with NullPool.
+
+    Celery tasks create a new asyncio event loop per invocation. The default
+    module-level ``engine`` keeps asyncpg connections in a pool whose
+    ``Future`` objects are bound to whichever loop first opened them, leading
+    to ``RuntimeError: ... attached to a different loop`` on later calls.
+    Using a fresh engine + ``NullPool`` per task invocation guarantees every
+    connection lives only on the current loop, then is closed at the end.
+    """
+    task_engine = create_async_engine(settings.database_url, echo=False, poolclass=NullPool)
+    factory = async_sessionmaker(task_engine, class_=AsyncSession, expire_on_commit=False)
+    return task_engine, factory

--- a/backend/app/core/encryption.py
+++ b/backend/app/core/encryption.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 _NONCE_BYTES = 12
 _KEY_BYTES = 32  # 256 bits
 _KEY_FILE = Path("/data/.paws_master_key")
+_KEY_FILE_FALLBACK = Path(".paws_master_key")
 _master_key: bytes | None = None
 
 
@@ -36,13 +37,14 @@ def _resolve_master_key() -> bytes:
         _master_key = raw
         return _master_key
 
-    # Try reading from persistent file
-    if _KEY_FILE.exists():
-        raw = base64.urlsafe_b64decode(_KEY_FILE.read_text().strip())
-        if len(raw) == _KEY_BYTES:
-            _master_key = raw
-            log.info("Loaded master key from %s", _KEY_FILE)
-            return _master_key
+    # Try reading from primary file, then fallback location
+    for candidate in (_KEY_FILE, _KEY_FILE_FALLBACK):
+        if candidate.exists():
+            raw = base64.urlsafe_b64decode(candidate.read_text().strip())
+            if len(raw) == _KEY_BYTES:
+                _master_key = raw
+                log.info("Loaded master key from %s", candidate)
+                return _master_key
 
     # Auto-generate and persist
     _master_key = secrets.token_bytes(_KEY_BYTES)
@@ -53,10 +55,9 @@ def _resolve_master_key() -> bytes:
         log.info("Generated and saved new master key to %s", _KEY_FILE)
     except OSError:
         # Fallback: write to working directory
-        fallback = Path(".paws_master_key")
-        fallback.write_text(base64.urlsafe_b64encode(_master_key).decode())
-        fallback.chmod(0o600)
-        log.warning("Could not write to %s, saved master key to %s", _KEY_FILE, fallback)
+        _KEY_FILE_FALLBACK.write_text(base64.urlsafe_b64encode(_master_key).decode())
+        _KEY_FILE_FALLBACK.chmod(0o600)
+        log.warning("Could not write to %s, saved master key to %s", _KEY_FILE, _KEY_FILE_FALLBACK)
 
     return _master_key
 

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -1,6 +1,9 @@
 """Rate-limiting, analytics, and setup-guard middleware using Redis."""
 
+import contextvars
+import logging
 import time
+import uuid
 
 from fastapi import Request, Response, status
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -9,6 +12,36 @@ from starlette.responses import JSONResponse
 from app.core.security import decode_token
 from app.services.rate_limiter import check_api_rate_limit
 
+_request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="-")
+
+
+def get_request_id() -> str:
+    return _request_id_var.get()
+
+
+class _RequestIDFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = _request_id_var.get()
+        return True
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Assigns a unique X-Request-ID to every request for traceability.
+
+    Reads from the incoming header if present; otherwise generates a UUID4.
+    The id is stored in a ContextVar so log formatters can include it.
+    """
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        req_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+        token = _request_id_var.set(req_id)
+        try:
+            response = await call_next(request)
+            response.headers["X-Request-ID"] = req_id
+            return response
+        finally:
+            _request_id_var.reset(token)
+
 
 class SetupGuardMiddleware(BaseHTTPMiddleware):
     """Returns 503 with setup_required flag when the app has not been initialized."""
@@ -16,6 +49,7 @@ class SetupGuardMiddleware(BaseHTTPMiddleware):
     ALLOWED_PREFIXES = (
         "/api/setup",
         "/health",
+        "/metrics",
         "/docs",
         "/openapi.json",
         "/favicon",
@@ -43,7 +77,7 @@ class SetupGuardMiddleware(BaseHTTPMiddleware):
 class AnalyticsMiddleware(BaseHTTPMiddleware):
     """Tracks per-user request counts and active sessions in Redis."""
 
-    EXEMPT_PREFIXES = ("/health", "/docs", "/openapi.json", "/favicon")
+    EXEMPT_PREFIXES = ("/health", "/metrics", "/docs", "/openapi.json", "/favicon")
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         path = request.url.path

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,12 @@
 import logging
 import sys
 from contextlib import asynccontextmanager
+from pathlib import Path
 
+import yaml
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
 from sqlalchemy import select
 
 from app.core.config import settings
@@ -11,8 +14,10 @@ from app.core.database import async_session
 from app.core.middleware import (
     AnalyticsMiddleware,
     RateLimitMiddleware,
+    RequestIDMiddleware,
     SecurityHeadersMiddleware,
     SetupGuardMiddleware,
+    _RequestIDFilter,
 )
 from app.core.security import hash_password
 from app.models.models import InstanceType, SystemSetting, User, UserQuota, UserRole
@@ -37,6 +42,7 @@ from app.routers import (
     dashboard,
     dns,
     docs,
+    drift,
     endpoints,
     events,
     groups,
@@ -68,6 +74,8 @@ from app.routers import (
 )
 
 logger = logging.getLogger(__name__)
+
+_SEEDS_DIR = Path(__file__).parent.parent / "seeds"
 
 
 def validate_security_settings() -> None:
@@ -208,43 +216,34 @@ async def seed_system_settings() -> None:
         logger.warning("Could not seed system settings - have you run 'alembic upgrade head'?")
 
 
-DEFAULT_INSTANCE_TYPES = [
-    ("paws.nano", 1, 512, 10, "general", "Nano - 1 vCPU, 512 MiB RAM, 10 GiB", 10),
-    ("paws.micro", 1, 1024, 20, "general", "Micro - 1 vCPU, 1 GiB RAM, 20 GiB", 20),
-    ("paws.small", 2, 2048, 40, "general", "Small - 2 vCPU, 2 GiB RAM, 40 GiB", 30),
-    ("paws.medium", 2, 4096, 80, "general", "Medium - 2 vCPU, 4 GiB RAM, 80 GiB", 40),
-    ("paws.large", 4, 8192, 160, "general", "Large - 4 vCPU, 8 GiB RAM, 160 GiB", 50),
-    ("paws.xlarge", 8, 16384, 320, "general", "XLarge - 8 vCPU, 16 GiB RAM, 320 GiB", 60),
-    ("paws.compute.small", 4, 2048, 40, "compute", "Compute Small - 4 vCPU, 2 GiB RAM", 110),
-    ("paws.compute.medium", 8, 4096, 40, "compute", "Compute Medium - 8 vCPU, 4 GiB RAM", 120),
-    ("paws.compute.large", 16, 8192, 40, "compute", "Compute Large - 16 vCPU, 8 GiB RAM", 130),
-    ("paws.memory.small", 2, 8192, 40, "memory", "Memory Small - 2 vCPU, 8 GiB RAM", 210),
-    ("paws.memory.medium", 4, 16384, 80, "memory", "Memory Medium - 4 vCPU, 16 GiB RAM", 220),
-    ("paws.memory.large", 8, 32768, 160, "memory", "Memory Large - 8 vCPU, 32 GiB RAM", 230),
-]
-
-
 async def seed_instance_types() -> None:
-    """Seed default instance types if none exist."""
+    """Seed default instance types from seeds/instance_types.yml if none exist."""
     try:
         async with async_session() as db:
             result = await db.execute(select(InstanceType).limit(1))
             if result.scalar_one_or_none() is not None:
                 return
-            for name, vcpus, ram_mib, disk_gib, category, description, sort_order in DEFAULT_INSTANCE_TYPES:
+            seeds_file = _SEEDS_DIR / "instance_types.yml"
+            if not seeds_file.exists():
+                logger.warning("seeds/instance_types.yml not found, skipping instance type seed")
+                return
+            with seeds_file.open() as f:
+                data = yaml.safe_load(f)
+            types = data.get("instance_types", [])
+            for t in types:
                 db.add(
                     InstanceType(
-                        name=name,
-                        vcpus=vcpus,
-                        ram_mib=ram_mib,
-                        disk_gib=disk_gib,
-                        category=category,
-                        description=description,
-                        sort_order=sort_order,
+                        name=t["name"],
+                        vcpus=t["vcpus"],
+                        ram_mib=t["ram_mib"],
+                        disk_gib=t["disk_gib"],
+                        category=t["category"],
+                        description=t["description"],
+                        sort_order=t.get("sort_order", 0),
                     )
                 )
             await db.commit()
-            logger.info("Default instance types seeded (%d types).", len(DEFAULT_INSTANCE_TYPES))
+            logger.info("Default instance types seeded from YAML (%d types).", len(types))
     except Exception:
         logger.warning("Could not seed instance types - have you run 'alembic upgrade head'?")
 
@@ -252,6 +251,11 @@ async def seed_instance_types() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.core.setup_state import check_initialized, is_initialized
+    from app.services.cluster_registry import cluster_registry
+
+    _req_id_filter = _RequestIDFilter()
+    for handler in logging.root.handlers:
+        handler.addFilter(_req_id_filter)
 
     validate_security_settings()
     await check_initialized()
@@ -259,6 +263,7 @@ async def lifespan(app: FastAPI):
         await seed_default_admin()
         await seed_system_settings()
         await seed_instance_types()
+        await cluster_registry.reload()
     yield
 
 
@@ -309,8 +314,14 @@ app.add_middleware(
     allow_origins=settings.cors_origin_list,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "Accept", "X-CSRF-Token"],
+    allow_headers=["Authorization", "Content-Type", "Accept", "X-CSRF-Token", "X-Request-ID"],
 )
+app.add_middleware(RequestIDMiddleware)
+
+Instrumentator(
+    should_group_status_codes=True,
+    excluded_handlers=["/health", "/metrics"],
+).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
 
 app.include_router(health.router)
 app.include_router(setup.router)
@@ -362,3 +373,4 @@ app.include_router(system_rules.router)
 app.include_router(groups.router)
 app.include_router(template_requests.router)
 app.include_router(docs.router)
+app.include_router(drift.router)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -1,4 +1,5 @@
 import enum
+import json as _json
 import uuid
 from datetime import datetime
 
@@ -203,6 +204,38 @@ class Resource(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+
+    @property
+    def cpu_cores(self) -> int | None:
+        """Convenience accessor for CPU cores stored in the specs JSON blob."""
+        try:
+            return _json.loads(self.specs or "{}").get("cores")
+        except (ValueError, AttributeError):
+            return None
+
+    @property
+    def ram_mb(self) -> int | None:
+        """Convenience accessor for RAM in MiB stored in the specs JSON blob."""
+        try:
+            return _json.loads(self.specs or "{}").get("memory_mb")
+        except (ValueError, AttributeError):
+            return None
+
+    @property
+    def disk_gb(self) -> int | None:
+        """Convenience accessor for disk in GiB stored in the specs JSON blob."""
+        try:
+            return _json.loads(self.specs or "{}").get("disk_gb")
+        except (ValueError, AttributeError):
+            return None
+
+    @property
+    def spec_hostname(self) -> str | None:
+        """Convenience accessor for hostname stored in the specs JSON blob."""
+        try:
+            return _json.loads(self.specs or "{}").get("hostname")
+        except (ValueError, AttributeError):
+            return None
 
     owner: Mapped["User"] = relationship(back_populates="resources")
     project: Mapped["Project | None"] = relationship(back_populates="resources")
@@ -938,3 +971,35 @@ class DocPage(Base):
 
     owner: Mapped["User"] = relationship(lazy="selectin")
     group: Mapped["UserGroup | None"] = relationship(lazy="selectin")
+
+
+# Drift types:
+# - orphaned_in_db       -- Resource in PAWS DB but VMID not found in Proxmox
+# - orphaned_in_proxmox  -- VM/LXC in Proxmox with a valid PAWS-ID but no matching DB row
+# - status_mismatch      -- DB status differs from Proxmox power state
+# - node_mismatch        -- DB proxmox_node differs from where Proxmox reports the VM
+
+
+class DriftEvent(Base):
+    """Records detected drift between the PAWS database and the Proxmox cluster.
+
+    Populated by the paws.scan_drift Celery task. Cleared by admin acknowledgement
+    or on the next scan when drift resolves.
+    """
+
+    __tablename__ = "drift_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    detected_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), index=True)
+    resource_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(), ForeignKey("resources.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    proxmox_vmid: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    proxmox_node: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    drift_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    details: Mapped[str | None] = mapped_column(Text, nullable=True)
+    acknowledged: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+    acknowledged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    acknowledged_by: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )

--- a/backend/app/routers/admin_connections.py
+++ b/backend/app/routers/admin_connections.py
@@ -157,10 +157,9 @@ async def create_connection(
     await db.commit()
     await db.refresh(conn)
 
-    # Trigger cluster registry reload
     from app.services.cluster_registry import cluster_registry
 
-    cluster_registry.invalidate()
+    await cluster_registry.reload()
 
     logger.info("Created %s connection '%s' -> %s:%d", body.conn_type, body.name, body.host, body.port)
     return _to_read(conn)
@@ -223,7 +222,7 @@ async def update_connection(
 
     from app.services.cluster_registry import cluster_registry
 
-    cluster_registry.invalidate()
+    await cluster_registry.reload()
 
     logger.info("Updated connection '%s'", conn.name)
     return _to_read(conn)
@@ -246,7 +245,7 @@ async def delete_connection(
 
     from app.services.cluster_registry import cluster_registry
 
-    cluster_registry.invalidate()
+    await cluster_registry.reload()
 
     logger.info("Deleted connection '%s'", conn.name)
 

--- a/backend/app/routers/backups.py
+++ b/backend/app/routers/backups.py
@@ -1,5 +1,6 @@
 """Backup and snapshot management endpoints."""
 
+import asyncio
 import json as _json
 import logging
 import uuid
@@ -15,10 +16,15 @@ from app.core.database import get_db
 from app.core.deps import get_current_active_user, require_admin
 from app.models.models import Backup, BackupPlan, Resource, SystemSetting, User, UserQuota
 from app.services.audit_service import log_action
+from app.services.cache import cache_delete, cached_call
 from app.services.proxmox_client import get_pve
 
 router = APIRouter(prefix="/api/backups", tags=["backups"])
 logger = logging.getLogger(__name__)
+
+
+def _snapshots_cache_key(resource: Resource, vmtype: str) -> str:
+    return f"pve:{resource.cluster_id or 'default'}:snapshots:{resource.proxmox_node}:{resource.proxmox_vmid}:{vmtype}"
 
 
 class SnapshotCreate(BaseModel):
@@ -65,11 +71,22 @@ async def list_snapshots(
 ):
     resource = await _get_resource(db, user.id, resource_id)
     vmtype = "lxc" if resource.resource_type == "lxc" else "qemu"
-    try:
-        snapshots = get_pve(resource.cluster_id).list_snapshots(resource.proxmox_node, resource.proxmox_vmid, vmtype)
-        return [s for s in snapshots if s.get("name") != "current"]
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=str(e))
+
+    cache_key = _snapshots_cache_key(resource, vmtype)
+
+    async def _fetch():
+        try:
+            snaps = await asyncio.to_thread(
+                get_pve(resource.cluster_id).list_snapshots,
+                resource.proxmox_node,
+                resource.proxmox_vmid,
+                vmtype,
+            )
+            return [s for s in snaps if s.get("name") != "current"]
+        except Exception as e:
+            raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return await cached_call(cache_key, 15, _fetch)
 
 
 @router.post("/{resource_id}/snapshots", status_code=status.HTTP_201_CREATED)
@@ -87,7 +104,10 @@ async def create_snapshot(
         if vmtype == "qemu" and body.include_ram:
             kwargs["vmstate"] = 1
         pve = get_pve(resource.cluster_id)
-        upid = pve.create_snapshot(resource.proxmox_node, resource.proxmox_vmid, body.name, vmtype, **kwargs)
+        upid = await asyncio.to_thread(
+            pve.create_snapshot, resource.proxmox_node, resource.proxmox_vmid, body.name, vmtype, **kwargs
+        )
+        await cache_delete(_snapshots_cache_key(resource, vmtype))
         await log_action(db, user.id, "snapshot_create", resource.resource_type, resource.id, {"snapshot": body.name})
         return {"status": "creating", "task": upid, "snapshot": body.name}
     except Exception as e:
@@ -106,7 +126,10 @@ async def rollback_snapshot(
 
     try:
         pve = get_pve(resource.cluster_id)
-        upid = pve.rollback_snapshot(resource.proxmox_node, resource.proxmox_vmid, body.name, vmtype)
+        upid = await asyncio.to_thread(
+            pve.rollback_snapshot, resource.proxmox_node, resource.proxmox_vmid, body.name, vmtype
+        )
+        await cache_delete(_snapshots_cache_key(resource, vmtype))
         await log_action(db, user.id, "snapshot_rollback", resource.resource_type, resource.id, {"snapshot": body.name})
         return {"status": "rolling_back", "task": upid}
     except Exception as e:
@@ -125,7 +148,10 @@ async def delete_snapshot(
 
     try:
         pve = get_pve(resource.cluster_id)
-        upid = pve.delete_snapshot(resource.proxmox_node, resource.proxmox_vmid, snapshot_name, vmtype)
+        upid = await asyncio.to_thread(
+            pve.delete_snapshot, resource.proxmox_node, resource.proxmox_vmid, snapshot_name, vmtype
+        )
+        await cache_delete(_snapshots_cache_key(resource, vmtype))
         await log_action(
             db, user.id, "snapshot_delete", resource.resource_type, resource.id, {"snapshot": snapshot_name}
         )
@@ -578,7 +604,13 @@ async def list_all_proxmox_backups(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_active_user),
 ):
-    """List ALL Proxmox backup files across all user's resources."""
+    """List ALL Proxmox backup files across all user's resources.
+
+    Cached per-user for 30 s in Redis. Per-cluster ``get_storage_list`` and
+    per-storage ``get_storage_content`` calls run concurrently via
+    ``asyncio.gather`` + ``to_thread`` so they no longer serialize the event
+    loop.
+    """
     # Get user's resources
     result = await db.execute(
         select(Resource).where(
@@ -587,68 +619,69 @@ async def list_all_proxmox_backups(
             Resource.status != "destroyed",
         )
     )
-    resources = result.scalars().all()
-    resource_map = {}
-    vmid_to_resource = {}
-    for r in resources:
-        resource_map[str(r.id)] = r
-        if r.proxmox_vmid:
-            vmid_to_resource[str(r.proxmox_vmid)] = r
+    resources = list(result.scalars().all())
+    vmid_to_resource = {str(r.proxmox_vmid): r for r in resources if r.proxmox_vmid}
 
     fallback_node = resources[0].proxmox_node if resources else None
     user_tag = f"[paws:{user.id}]"
-    backups: list[dict] = []
-
     cluster_ids = {r.cluster_id for r in resources}
-    for cid in cluster_ids:
-        try:
-            pve = get_pve(cid)
-            storages = pve.get_storage_list()
-            for s in storages:
-                if "backup" not in s.get("content", ""):
-                    continue
+
+    cache_key = f"backup_list_proxmox_all:{user.id}"
+
+    async def _scan() -> list[dict]:
+        async def _scan_cluster(cid: str | None) -> list[dict]:
+            try:
+                pve = get_pve(cid)
+                storages = await asyncio.to_thread(pve.get_storage_list)
+            except Exception:
+                return []
+            backup_storages = [s for s in storages if "backup" in (s.get("content") or "")]
+
+            async def _scan_storage(s: dict) -> list[dict]:
                 try:
                     node = _resolve_node(s, fallback_node, cid)
-                    contents = pve.get_storage_content(node, s["storage"])
-                    is_pbs = s.get("type") == "pbs"
-                    for item in contents:
-                        if item.get("content") != "backup":
-                            continue
-                        notes = item.get("notes", "") or ""
-                        if user_tag not in notes:
-                            continue
-                        volid = item.get("volid", "")
-                        # Match to resource by VMID
-                        matched_resource = None
-                        for vmid_str, r in vmid_to_resource.items():
-                            if vmid_str in volid:
-                                matched_resource = r
-                                break
-
-                        entry = {
-                            "volid": volid,
-                            "size": item.get("size", 0),
-                            "ctime": item.get("ctime", 0),
-                            "format": item.get("format", "pbs" if is_pbs else ""),
-                            "storage": s["storage"],
-                            "notes": notes,
-                            "pbs": is_pbs,
-                            "resource_id": str(matched_resource.id) if matched_resource else None,
-                            "resource_name": matched_resource.display_name if matched_resource else None,
-                            "resource_type": matched_resource.resource_type if matched_resource else None,
-                            "vmid": matched_resource.proxmox_vmid if matched_resource else None,
-                            "node": matched_resource.proxmox_node if matched_resource else (s.get("node") or None),
-                        }
-                        if is_pbs:
-                            entry["backup_type"] = "ct" if "/ct/" in volid else "vm"
-                            entry["backup_time"] = item.get("ctime", 0)
-                        backups.append(entry)
+                    contents = await asyncio.to_thread(pve.get_storage_content, node, s["storage"])
                 except Exception:
-                    pass
-        except Exception:
-            pass
+                    return []
+                is_pbs = s.get("type") == "pbs"
+                out: list[dict] = []
+                for item in contents:
+                    if item.get("content") != "backup":
+                        continue
+                    notes = item.get("notes", "") or ""
+                    if user_tag not in notes:
+                        continue
+                    volid = item.get("volid", "")
+                    matched = next((r for vmid, r in vmid_to_resource.items() if vmid in volid), None)
+                    entry = {
+                        "volid": volid,
+                        "size": item.get("size", 0),
+                        "ctime": item.get("ctime", 0),
+                        "format": item.get("format", "pbs" if is_pbs else ""),
+                        "storage": s["storage"],
+                        "notes": notes,
+                        "pbs": is_pbs,
+                        "resource_id": str(matched.id) if matched else None,
+                        "resource_name": matched.display_name if matched else None,
+                        "resource_type": matched.resource_type if matched else None,
+                        "vmid": matched.proxmox_vmid if matched else None,
+                        "node": matched.proxmox_node if matched else (s.get("node") or None),
+                    }
+                    if is_pbs:
+                        entry["backup_type"] = "ct" if "/ct/" in volid else "vm"
+                        entry["backup_time"] = item.get("ctime", 0)
+                    out.append(entry)
+                return out
 
-    backups.sort(key=lambda b: b.get("ctime", 0), reverse=True)
+            results = await asyncio.gather(*[_scan_storage(s) for s in backup_storages])
+            return [item for sub in results for item in sub]
+
+        cluster_results = await asyncio.gather(*[_scan_cluster(cid) for cid in cluster_ids])
+        all_backups = [b for sub in cluster_results for b in sub]
+        all_backups.sort(key=lambda b: b.get("ctime", 0), reverse=True)
+        return all_backups
+
+    backups = await cached_call(cache_key, 30, _scan)
     return {"backups": backups, "total": len(backups)}
 
 
@@ -657,15 +690,20 @@ async def backup_quota_summary(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_active_user),
 ):
-    """Get backup quota usage for the current user."""
-    # Quota limits
+    """Get backup quota usage for the current user.
+
+    Cached per-user for 30 s in Redis because the underlying Proxmox calls
+    (per-VM ``list_snapshots`` + per-storage ``get_storage_content``) are
+    expensive and the data is only used for an at-a-glance UI counter.
+    """
+    # Quota limits (always read fresh from DB)
     q_result = await db.execute(select(UserQuota).where(UserQuota.user_id == user.id))
     quota = q_result.scalar_one_or_none()
     max_snapshots = quota.max_snapshots if quota else 10
     max_backups = quota.max_backups if quota else 20
     max_backup_size_gb = quota.max_backup_size_gb if quota else 100
 
-    # DB backup records count
+    # DB backup records count (cheap)
     count_result = await db.execute(
         select(func.count(Backup.id)).where(
             Backup.owner_id == user.id,
@@ -674,7 +712,7 @@ async def backup_quota_summary(
     )
     db_backup_count = count_result.scalar() or 0
 
-    # Snapshot count from Proxmox (live per-resource)
+    # User's VM/LXC resources (needed to look up live counts from PVE)
     res_result = await db.execute(
         select(Resource).where(
             Resource.owner_id == user.id,
@@ -682,55 +720,86 @@ async def backup_quota_summary(
             Resource.status != "destroyed",
         )
     )
-    all_resources = res_result.scalars().all()
-    snapshot_count = 0
-    for r in all_resources:
-        if not r.proxmox_vmid or not r.proxmox_node:
-            continue
-        try:
-            vmtype = "lxc" if r.resource_type == "lxc" else "qemu"
-            snaps = get_pve(r.cluster_id).list_snapshots(r.proxmox_node, r.proxmox_vmid, vmtype)
-            snapshot_count += len([s for s in snaps if s.get("name") != "current"])
-        except Exception:
-            pass
+    all_resources = list(res_result.scalars().all())
 
-    # Proxmox backup files total size
-    fallback_node = all_resources[0].proxmox_node if all_resources else None
-    user_tag = f"[paws:{user.id}]"
-    total_backup_size = 0
-    proxmox_backup_count = 0
-    cluster_ids = {r.cluster_id for r in all_resources}
-    for cid in cluster_ids:
-        try:
-            pve = get_pve(cid)
-            storages = pve.get_storage_list()
-            for s in storages:
-                if "backup" not in s.get("content", ""):
-                    continue
+    # Heavy section: snapshot count + proxmox backup totals.
+    # Per-VM list_snapshots and per-storage get_storage_content are sync HTTP
+    # calls; running them serially in an async handler blocks the event loop
+    # and serializes every other request. Parallelize with to_thread + gather
+    # and cache the aggregate per-user.
+    cache_key = f"backup_quota_summary:{user.id}"
+
+    async def _compute_pve_counts() -> dict:
+        # --- Snapshots: one call per resource, run in parallel ---
+        async def _count_snaps(r: Resource) -> int:
+            if not r.proxmox_vmid or not r.proxmox_node:
+                return 0
+            try:
+                vmtype = "lxc" if r.resource_type == "lxc" else "qemu"
+                snaps = await asyncio.to_thread(
+                    get_pve(r.cluster_id).list_snapshots, r.proxmox_node, r.proxmox_vmid, vmtype
+                )
+                return len([s for s in snaps if s.get("name") != "current"])
+            except Exception:
+                return 0
+
+        snap_counts = await asyncio.gather(*[_count_snaps(r) for r in all_resources])
+        total_snaps = sum(snap_counts)
+
+        # --- Proxmox backup files: one call per (cluster, storage), parallelized ---
+        fallback_node = all_resources[0].proxmox_node if all_resources else None
+        user_tag = f"[paws:{user.id}]"
+        cluster_ids = {r.cluster_id for r in all_resources}
+
+        async def _scan_cluster(cid: str | None) -> tuple[int, int]:
+            try:
+                pve = get_pve(cid)
+                storages = await asyncio.to_thread(pve.get_storage_list)
+            except Exception:
+                return 0, 0
+            backup_storages = [s for s in storages if "backup" in (s.get("content") or "")]
+
+            async def _scan_storage(s: dict) -> tuple[int, int]:
                 try:
                     node = _resolve_node(s, fallback_node, cid)
-                    contents = pve.get_storage_content(node, s["storage"])
-                    for item in contents:
-                        if item.get("content") != "backup":
-                            continue
-                        if user_tag not in (item.get("notes", "") or ""):
-                            continue
-                        proxmox_backup_count += 1
-                        total_backup_size += item.get("size", 0)
+                    contents = await asyncio.to_thread(pve.get_storage_content, node, s["storage"])
                 except Exception:
-                    pass
-        except Exception:
-            pass
+                    return 0, 0
+                cnt = 0
+                size = 0
+                for item in contents:
+                    if item.get("content") != "backup":
+                        continue
+                    if user_tag not in (item.get("notes", "") or ""):
+                        continue
+                    cnt += 1
+                    size += item.get("size", 0)
+                return cnt, size
+
+            results = await asyncio.gather(*[_scan_storage(s) for s in backup_storages])
+            return sum(c for c, _ in results), sum(sz for _, sz in results)
+
+        cluster_results = await asyncio.gather(*[_scan_cluster(cid) for cid in cluster_ids])
+        total_backup_count = sum(c for c, _ in cluster_results)
+        total_backup_size = sum(sz for _, sz in cluster_results)
+
+        return {
+            "snapshot_count": total_snaps,
+            "proxmox_backup_count": total_backup_count,
+            "total_backup_size": total_backup_size,
+        }
+
+    pve_counts = await cached_call(cache_key, 30, _compute_pve_counts)
 
     return {
         "max_snapshots": max_snapshots,
         "max_backups": max_backups,
         "max_backup_size_gb": max_backup_size_gb,
-        "snapshot_count": snapshot_count,
+        "snapshot_count": pve_counts["snapshot_count"],
         "db_backup_count": db_backup_count,
-        "proxmox_backup_count": proxmox_backup_count,
-        "total_backup_size": total_backup_size,
-        "total_count": snapshot_count + proxmox_backup_count,
+        "proxmox_backup_count": pve_counts["proxmox_backup_count"],
+        "total_backup_size": pve_counts["total_backup_size"],
+        "total_count": pve_counts["snapshot_count"] + pve_counts["proxmox_backup_count"],
     }
 
 

--- a/backend/app/routers/cluster.py
+++ b/backend/app/routers/cluster.py
@@ -29,16 +29,21 @@ async def list_available_clusters(_: User = Depends(get_current_active_user)) ->
     return [{"name": cid} for cid in cluster_registry.list_cluster_ids()]
 
 
-async def _compute_cluster_status(cluster_id: str | None) -> dict[str, Any]:
+async def _compute_cluster_status() -> dict[str, Any]:
     """Call Proxmox and build the sanitized cluster status payload."""
+    from app.services.proxmox_cache import get_cluster_status as _cached_status
+    from app.services.proxmox_cache import get_nodes as _cached_nodes
+
     try:
-        pve = get_pve(cluster_id)
+        # Touch the registry to ensure NoClustersConfigured can fast-fail.
+        get_pve()
     except NoClustersConfigured:
         return {"api_reachable": False, "cached_at": now_epoch()}
-    try:
-        nodes = pve.get_nodes()
-        cluster_info = pve.get_cluster_status()
-    except Exception:
+
+    nodes = await _cached_nodes()
+    cluster_info = await _cached_status()
+    if not nodes and not cluster_info:
+        # Both empty likely means PVE unreachable (helpers swallow + log).
         logger.warning("Proxmox API unreachable for cluster health check")
         return {"api_reachable": False, "cached_at": now_epoch()}
 
@@ -83,11 +88,11 @@ async def cluster_health(
     Results are cached in Redis for a short TTL so dashboard loads do not
     hit the Proxmox API on every request.
     """
-    cache_key = f"cluster_status:{cluster_id or 'default'}"
+    cache_key = "cluster_status"
     payload = await cached_call(
         cache_key,
         CLUSTER_STATUS_TTL_SECONDS,
-        lambda: _compute_cluster_status(cluster_id),
+        _compute_cluster_status,
     )
 
     if not payload.get("api_reachable"):

--- a/backend/app/routers/compute.py
+++ b/backend/app/routers/compute.py
@@ -19,6 +19,7 @@ from app.core.lifecycle import validate_instance_specs
 from app.models.models import VPC, Resource, SSHKeyPair, Subnet, SystemSetting, User, UserQuota, VMIDPool, Volume
 from app.services.audit_service import log_action
 from app.services.cache import cache_delete, cached_call
+from app.services.cluster_registry import NoClustersConfigured, cluster_registry
 from app.services.firewall_profile import FirewallProfileService
 from app.services.node_service import get_next_vmid, select_node
 from app.services.pool_service import add_resource_to_pool, cleanup_user_pool, ensure_user_pool
@@ -374,13 +375,20 @@ async def create_vm(
     except RuntimeError as e:
         raise HTTPException(status_code=503, detail=str(e))
 
+    try:
+        _cluster_id = cluster_registry.default_cluster
+    except NoClustersConfigured:
+        raise HTTPException(
+            status_code=503, detail="No Proxmox cluster configured. Add one via Admin > Infrastructure."
+        )
+
     # Reserve VMID first (without creating resource yet)
     db.add(VMIDPool(vmid=new_vmid, resource_id=None))
     await db.commit()
 
     # Find template's source node and determine clone strategy
     try:
-        pve = get_pve(body.cluster_id)
+        pve = get_pve()
         template_node = pve.find_vm_node(body.template_vmid)
         if not template_node:
             raise RuntimeError(f"Template VMID {body.template_vmid} not found on any node")
@@ -440,7 +448,7 @@ async def create_vm(
         proxmox_node=clone_node,
         status="provisioning",
         termination_protected=body.termination_protected,
-        cluster_id=body.cluster_id,
+        cluster_id=_cluster_id,
         specs=json.dumps(
             {
                 "cores": body.cores,
@@ -581,6 +589,7 @@ async def list_vms(
     result = await db.execute(query)
     resources = result.scalars().all()
     vms = []
+    batch = await _get_batch_vm_statuses()
     for r in resources:
         vm_data = {
             "id": str(r.id),
@@ -595,18 +604,14 @@ async def list_vms(
             "created_at": str(r.created_at),
             "last_accessed_at": r.last_accessed_at.isoformat() if r.last_accessed_at else None,
         }
-        # Fetch live status if running (Redis-cached; ~5s TTL)
         if r.status not in ("destroyed", "error", "creating") and r.proxmox_vmid and r.proxmox_node:
-            try:
-                live = await _get_live_status_cached(r)
-                vm_data["live_status"] = live.get("status")
-                vm_data["cpu_usage"] = live.get("cpu", 0)
-                vm_data["mem_usage"] = live.get("mem", 0)
-                vm_data["uptime"] = live.get("uptime", 0)
-                vm_data["netin"] = live.get("netin", 0)
-                vm_data["netout"] = live.get("netout", 0)
-            except Exception:
-                vm_data["live_status"] = "unknown"
+            pve_data = batch.get(r.proxmox_vmid, {})
+            vm_data["live_status"] = pve_data.get("status")
+            vm_data["cpu_usage"] = pve_data.get("cpu", 0)
+            vm_data["mem_usage"] = pve_data.get("mem", 0)
+            vm_data["uptime"] = pve_data.get("uptime", 0)
+            vm_data["netin"] = pve_data.get("netin", 0)
+            vm_data["netout"] = pve_data.get("netout", 0)
         vms.append(vm_data)
     return vms
 
@@ -1264,15 +1269,31 @@ async def update_vm_network(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_active_user),
 ):
-    """Update a VM's network interface to use a specific user VPC with static IP."""
+    """Migrate a VM's primary NIC (net0) to a different VPC with a fresh static IP.
+
+    Consistency contract:
+    - Pre-validates target VPC has an allocatable IP before mutating anything.
+    - Stages the new IPReservation in the DB (via flush) so unique-constraint
+      conflicts surface BEFORE we touch Proxmox.
+    - Snapshots the prior PVE NIC config so we can roll back on partial failure.
+    - PVE write happens AFTER DB stage; commit happens AFTER PVE write succeeds.
+    - On any PVE failure, we restore the previous PVE config and rollback the DB.
+    - Only ``net0`` is supported; secondary NICs use the dedicated NIC endpoints
+      so primary-VPC reservations and cloud-init ipconfig0 stay consistent.
+    """
     import ipaddress as _ipaddr
-
-    resource = await _get_user_resource(db, user.id, resource_id, "vm", min_group_perm="admin")
-
-    # Validate the VPC belongs to this user
     import uuid as _uuid
 
     from app.models.models import VPC, IPReservation
+
+    if body.net_id != "net0":
+        raise HTTPException(
+            status_code=400,
+            detail="This endpoint only migrates the primary NIC (net0). "
+            "Use /network/nics endpoints for secondary NICs.",
+        )
+
+    resource = await _get_user_resource(db, user.id, resource_id, "vm", min_group_perm="admin")
 
     try:
         vpc_uuid = _uuid.UUID(body.vpc_id)
@@ -1285,109 +1306,172 @@ async def update_vm_network(
     if not vpc.proxmox_vnet:
         raise HTTPException(status_code=400, detail="VPC has no Proxmox vnet configured")
 
-    # Release any old IP reservations for this resource
-    await db.execute(delete(IPReservation).where(IPReservation.resource_id == resource.id))
-
-    # Auto-allocate static IP from first active subnet
+    # ----- 1. Find a usable subnet + free IP in target VPC ------------------
     subnet_result = await db.execute(
         select(Subnet)
         .where(Subnet.vpc_id == vpc.id, Subnet.status == "active")
         .options(selectinload(Subnet.ip_reservations))
-        .limit(1)
     )
-    subnet = subnet_result.scalar_one_or_none()
-
-    ip_str = None
-    prefix_len = None
-    gateway = None
-    if subnet:
+    candidate: tuple[Subnet, str, int, str] | None = None  # (subnet, ip, prefix, gateway)
+    for subnet in subnet_result.scalars().all():
         try:
             network = _ipaddr.ip_network(subnet.cidr, strict=False)
-            prefix_len = network.prefixlen
-            gateway = subnet.gateway or str(list(network.hosts())[0])
-            used_ips = {r.ip_address for r in subnet.ip_reservations}
-            for host in list(network.hosts())[1:]:
-                if str(host) not in used_ips:
-                    ip_str = str(host)
-                    break
-            if ip_str:
-                db.add(
-                    IPReservation(
-                        subnet_id=subnet.id,
-                        ip_address=ip_str,
-                        resource_id=resource.id,
-                        label=resource.display_name,
-                        is_gateway=False,
-                        owner_id=user.id,
-                        cluster_id=vpc.cluster_id,
+        except ValueError:
+            continue
+        prefix_len = network.prefixlen
+        gateway = subnet.gateway or str(list(network.hosts())[0])
+        used_ips = {r.ip_address for r in subnet.ip_reservations}
+        excluded = used_ips | {gateway, str(network.network_address), str(network.broadcast_address)}
+        for host in network.hosts():
+            ip_str = str(host)
+            if ip_str not in excluded:
+                candidate = (subnet, ip_str, prefix_len, gateway)
+                break
+        if candidate:
+            break
+
+    if not candidate:
+        raise HTTPException(
+            status_code=409,
+            detail="Target VPC has no available IP in any active subnet. "
+            "Add a subnet, expand an existing one, or release reservations first.",
+        )
+
+    subnet, ip_str, prefix_len, gateway = candidate
+    dns_server = subnet.dns_server or "1.1.1.1"
+
+    # ----- 2. Snapshot old PVE config for rollback --------------------------
+    vmtype = "lxc" if resource.resource_type == "lxc" else "qemu"
+    pve = get_pve(resource.cluster_id)
+    old_pve_config: dict[str, str] = {}
+    try:
+        if vmtype == "lxc":
+            cur_cfg = pve.get_container_config(resource.proxmox_node, resource.proxmox_vmid)
+            if isinstance(cur_cfg, dict) and "net0" in cur_cfg:
+                old_pve_config["net0"] = cur_cfg["net0"]
+        else:
+            cur_cfg = pve.get_vm_config(resource.proxmox_node, resource.proxmox_vmid)
+            if isinstance(cur_cfg, dict):
+                for key in ("net0", "ipconfig0", "nameserver"):
+                    if key in cur_cfg:
+                        old_pve_config[key] = cur_cfg[key]
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to read current Proxmox config: {exc}",
+        ) from exc
+
+    # ----- 3. Stage DB changes (delete old primary reservation, add new) ----
+    # Identify the old primary reservation: it lives in a subnet of the OLD VPC
+    # (from specs.vpc_id) and has label == display_name (secondary NICs use
+    # "{display_name}-{net_id}" labels and must not be touched).
+    specs = json.loads(resource.specs) if resource.specs else {}
+    old_vpc_id = specs.get("vpc_id")
+    if old_vpc_id:
+        try:
+            old_vpc_uuid = _uuid.UUID(old_vpc_id)
+        except ValueError:
+            old_vpc_uuid = None
+        if old_vpc_uuid:
+            old_subnet_ids_q = await db.execute(select(Subnet.id).where(Subnet.vpc_id == old_vpc_uuid))
+            old_subnet_ids = list(old_subnet_ids_q.scalars().all())
+            if old_subnet_ids:
+                await db.execute(
+                    delete(IPReservation).where(
+                        IPReservation.resource_id == resource.id,
+                        IPReservation.subnet_id.in_(old_subnet_ids),
+                        IPReservation.label == resource.display_name,
                     )
                 )
-        except Exception:
-            logger.warning("Failed to allocate IP for network change on %s", resource_id, exc_info=True)
 
-    # Build and apply the NIC via unified helpers
-    vmtype = resource.resource_type if resource.resource_type == "lxc" else "qemu"
-    try:
-        net0_val = _build_net0(
-            vmtype,
-            vpc.proxmox_vnet,
-            ip=ip_str,
-            prefix_len=prefix_len,
-            gateway=gateway,
-            firewall=body.firewall,
-            model=body.model,
+    db.add(
+        IPReservation(
+            subnet_id=subnet.id,
+            ip_address=ip_str,
+            resource_id=resource.id,
+            label=resource.display_name,
+            is_gateway=False,
+            owner_id=user.id,
+            cluster_id=vpc.cluster_id,
         )
-        dns = (subnet.dns_server or "1.1.1.1") if subnet else "1.1.1.1"
+    )
+    try:
+        await db.flush()  # surface unique constraint conflicts BEFORE PVE write
+    except Exception as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=f"Failed to reserve IP {ip_str}: {exc}",
+        ) from exc
 
-        # Check if running - NIC bridge changes require stop/start for VMs
-        pve = get_pve(resource.cluster_id)
-        was_running = False
-        if vmtype != "lxc":
-            try:
-                st = pve.get_vm_status(resource.proxmox_node, resource.proxmox_vmid)
-                was_running = st.get("status") == "running"
-                if was_running:
-                    upid = pve.stop_vm(resource.proxmox_node, resource.proxmox_vmid)
-                    pve.wait_for_task(resource.proxmox_node, upid, timeout=60)
-            except Exception:
-                pass
+    # ----- 4. Stop instance if running (must succeed; no silent swallow) ----
+    was_running = False
+    try:
+        if vmtype == "lxc":
+            st = pve.get_container_status(resource.proxmox_node, resource.proxmox_vmid)
         else:
-            try:
-                st = pve.get_container_status(resource.proxmox_node, resource.proxmox_vmid)
-                was_running = st.get("status") == "running"
-                if was_running:
-                    upid = pve.stop_container(resource.proxmox_node, resource.proxmox_vmid)
-                    pve.wait_for_task(resource.proxmox_node, upid, timeout=60)
-            except Exception:
-                pass
+            st = pve.get_vm_status(resource.proxmox_node, resource.proxmox_vmid)
+        was_running = (st or {}).get("status") == "running"
+    except Exception as exc:
+        await db.rollback()
+        raise HTTPException(status_code=502, detail=f"Failed to query instance status: {exc}") from exc
 
-        # For net0, use _apply_nic; for other NICs, apply directly
-        if body.net_id == "net0":
-            _apply_nic(
+    if was_running:
+        try:
+            if vmtype == "lxc":
+                upid = pve.stop_container(resource.proxmox_node, resource.proxmox_vmid)
+            else:
+                upid = pve.stop_vm(resource.proxmox_node, resource.proxmox_vmid)
+            pve.wait_for_task(resource.proxmox_node, upid, timeout=60)
+        except Exception as exc:
+            await db.rollback()
+            raise HTTPException(status_code=502, detail=f"Failed to stop instance: {exc}") from exc
+
+    # ----- 5. Apply new config to PVE; restore old on failure ---------------
+    net0_val = _build_net0(
+        vmtype,
+        vpc.proxmox_vnet,
+        ip=ip_str,
+        prefix_len=prefix_len,
+        gateway=gateway,
+        firewall=body.firewall,
+        model=body.model,
+    )
+
+    def _restore_pve_config():
+        try:
+            if vmtype == "lxc":
+                if "net0" in old_pve_config:
+                    pve.set_container_config(resource.proxmox_node, resource.proxmox_vmid, net0=old_pve_config["net0"])
+            else:
+                restore_kwargs = {k: v for k, v in old_pve_config.items()}
+                if restore_kwargs:
+                    pve.update_vm_config(resource.proxmox_node, resource.proxmox_vmid, **restore_kwargs)
+                    try:
+                        pve.regenerate_cloudinit(resource.proxmox_node, resource.proxmox_vmid)
+                    except Exception:
+                        logger.warning(
+                            "Failed to regenerate cloud-init during rollback for vmid=%s", resource.proxmox_vmid
+                        )
+        except Exception:
+            logger.exception("Failed to roll back PVE config for vmid=%s", resource.proxmox_vmid)
+
+    try:
+        if vmtype == "lxc":
+            pve.set_container_config(resource.proxmox_node, resource.proxmox_vmid, net0=net0_val)
+        else:
+            pve.update_vm_config(
                 resource.proxmox_node,
                 resource.proxmox_vmid,
-                vmtype,
-                net0_val,
-                cluster_id=resource.cluster_id,
-                ip=ip_str,
-                prefix_len=prefix_len,
-                gateway=gateway,
-                dns_server=dns,
+                net0=net0_val,
+                agent="1",
+                ipconfig0=f"ip={ip_str}/{prefix_len},gw={gateway}",
+                nameserver=dns_server,
             )
-        else:
-            if vmtype == "lxc":
-                pve.set_container_config(resource.proxmox_node, resource.proxmox_vmid, **{body.net_id: net0_val})
-            else:
-                pve.update_vm_config(resource.proxmox_node, resource.proxmox_vmid, **{body.net_id: net0_val})
-
-        specs = json.loads(resource.specs) if resource.specs else {}
-        specs["vpc_id"] = str(vpc.id)
-        if ip_str:
-            specs["ip_address"] = ip_str
-        resource.specs = json.dumps(specs)
-        await db.commit()
-
-        # Restart if it was running before the NIC change
+            pve.regenerate_cloudinit(resource.proxmox_node, resource.proxmox_vmid)
+    except Exception as exc:
+        _restore_pve_config()
+        await db.rollback()
         if was_running:
             try:
                 if vmtype == "lxc":
@@ -1396,16 +1480,54 @@ async def update_vm_network(
                     pve.start_vm(resource.proxmox_node, resource.proxmox_vmid)
             except Exception:
                 pass
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to apply network change to Proxmox; previous config restored: {exc}",
+        ) from exc
 
-        return {
-            "status": "ok",
-            "vpc": {"id": str(vpc.id), "name": vpc.name, "vnet": vpc.proxmox_vnet},
-            "ip_address": ip_str,
-            "restarted": was_running,
-            "message": "Instance was restarted to apply the network change." if was_running else "Network updated.",
-        }
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=str(e))
+    # ----- 6. Update specs and commit ---------------------------------------
+    specs["vpc_id"] = str(vpc.id)
+    specs["ip_address"] = ip_str
+    resource.specs = json.dumps(specs)
+    try:
+        await db.commit()
+    except Exception as exc:
+        # PVE was already mutated; attempt to roll PVE back to keep states consistent.
+        _restore_pve_config()
+        if was_running:
+            try:
+                if vmtype == "lxc":
+                    pve.start_container(resource.proxmox_node, resource.proxmox_vmid)
+                else:
+                    pve.start_vm(resource.proxmox_node, resource.proxmox_vmid)
+            except Exception:
+                pass
+        raise HTTPException(
+            status_code=500,
+            detail=f"DB commit failed; PVE rolled back: {exc}",
+        ) from exc
+
+    # ----- 7. Restart if it was running before ------------------------------
+    if was_running:
+        try:
+            if vmtype == "lxc":
+                pve.start_container(resource.proxmox_node, resource.proxmox_vmid)
+            else:
+                pve.start_vm(resource.proxmox_node, resource.proxmox_vmid)
+        except Exception:
+            logger.warning(
+                "Network migration committed but failed to restart vmid=%s",
+                resource.proxmox_vmid,
+            )
+
+    return {
+        "status": "ok",
+        "vpc": {"id": str(vpc.id), "name": vpc.name, "vnet": vpc.proxmox_vnet},
+        "ip_address": ip_str,
+        "subnet": subnet.cidr,
+        "restarted": was_running,
+        "message": ("Instance was restarted to apply the network change." if was_running else "Network updated."),
+    }
 
 
 class NICAddRequest(BaseModel):
@@ -2158,12 +2280,19 @@ async def create_container(
     new_vmid = get_next_vmid(existing, start=vmid_start, end=vmid_end)
     node = select_node("least-loaded")
 
+    try:
+        _cluster_id = cluster_registry.default_cluster
+    except NoClustersConfigured:
+        raise HTTPException(
+            status_code=503, detail="No Proxmox cluster configured. Add one via Admin > Infrastructure."
+        )
+
     # Reserve VMID first
     db.add(VMIDPool(vmid=new_vmid, resource_id=None))
     await db.commit()
 
     try:
-        pve = get_pve(body.cluster_id)
+        pve = get_pve()
         if body.template_vmid:
             # Clone from CT template (same logic as VM cloning)
             template_node = pve.find_vm_node(body.template_vmid)
@@ -2211,7 +2340,7 @@ async def create_container(
             proxmox_vmid=new_vmid,
             proxmox_node=clone_node,
             status="provisioning",
-            cluster_id=body.cluster_id,
+            cluster_id=_cluster_id,
             specs=json.dumps(ct_specs),
         )
         db.add(resource)
@@ -2312,6 +2441,7 @@ async def list_containers(
     )
     resources = result.scalars().all()
     containers = []
+    batch = await _get_batch_vm_statuses()
     for r in resources:
         ct_data = {
             "id": str(r.id),
@@ -2324,11 +2454,8 @@ async def list_containers(
             "last_accessed_at": r.last_accessed_at.isoformat() if r.last_accessed_at else None,
         }
         if r.status not in ("destroyed", "error", "creating") and r.proxmox_vmid and r.proxmox_node:
-            try:
-                live = await _get_live_status_cached(r)
-                ct_data["live_status"] = live.get("status")
-            except Exception:
-                ct_data["live_status"] = "unknown"
+            pve_data = batch.get(r.proxmox_vmid, {})
+            ct_data["live_status"] = pve_data.get("status")
         containers.append(ct_data)
     return containers
 
@@ -2733,6 +2860,19 @@ def _get_live_status(resource: Resource) -> dict:
 # Keys the VM/LXC live-status cache uses. TTL is short (5s) so user-visible
 # state still reflects reality without hammering PVE on every list page load.
 _VM_STATUS_TTL_SECONDS = 5
+
+_BATCH_STATUS_TTL_SECONDS = 10
+
+
+async def _get_batch_vm_statuses() -> dict[int, dict]:
+    """Fetch all VM/LXC statuses in a single Proxmox cluster/resources call.
+
+    Returns a dict keyed by vmid (int) -> resource dict from Proxmox.
+    Backed by the shared Redis-cached + async-safe helper in proxmox_cache.
+    """
+    from app.services.proxmox_cache import get_vm_status_map
+
+    return await get_vm_status_map()
 
 
 def _vm_status_cache_key(resource: Resource) -> str:

--- a/backend/app/routers/drift.py
+++ b/backend/app/routers/drift.py
@@ -1,0 +1,250 @@
+"""Admin endpoints for viewing and acknowledging drift events."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import require_admin
+from app.models.models import DriftEvent, Resource, User
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin/drift", tags=["drift"])
+
+# Drift types that can be auto-fixed by syncing the PAWS DB to match Proxmox state.
+AUTO_FIXABLE_TYPES = {"status_mismatch", "node_mismatch"}
+
+_PVE_STATUS_MAP = {
+    "running": "running",
+    "stopped": "stopped",
+    "paused": "stopped",
+    "suspended": "stopped",
+}
+
+
+@router.get("")
+async def list_drift_events(
+    acknowledged: bool | None = None,
+    _: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict[str, Any]]:
+    """List drift events. Pass ?acknowledged=false to see only active drift."""
+    q = select(DriftEvent).order_by(DriftEvent.detected_at.desc()).limit(200)
+    if acknowledged is not None:
+        q = q.where(DriftEvent.acknowledged == acknowledged)
+    result = await db.execute(q)
+    events = result.scalars().all()
+
+    resource_ids = {e.resource_id for e in events if e.resource_id}
+    resource_names: dict[uuid.UUID, str] = {}
+    if resource_ids:
+        r_result = await db.execute(select(Resource).where(Resource.id.in_(resource_ids)))
+        for r in r_result.scalars().all():
+            resource_names[r.id] = r.display_name
+
+    return [
+        {
+            "id": str(e.id),
+            "detected_at": e.detected_at.isoformat() if e.detected_at else None,
+            "resource_id": str(e.resource_id) if e.resource_id else None,
+            "resource_name": resource_names.get(e.resource_id) if e.resource_id else None,
+            "proxmox_vmid": e.proxmox_vmid,
+            "proxmox_node": e.proxmox_node,
+            "drift_type": e.drift_type,
+            "details": e.details,
+            "acknowledged": e.acknowledged,
+            "acknowledged_at": e.acknowledged_at.isoformat() if e.acknowledged_at else None,
+            "auto_fixable": e.drift_type in AUTO_FIXABLE_TYPES and e.resource_id is not None,
+        }
+        for e in events
+    ]
+
+
+@router.post("/{event_id}/fix")
+async def fix_drift_event(
+    event_id: uuid.UUID,
+    _: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Auto-fix an auto-fixable drift event by syncing PAWS DB to current Proxmox state.
+
+    Supported drift types: status_mismatch, node_mismatch. PVE is treated as the
+    source of truth (e.g., the user started/stopped a VM directly on Proxmox, or
+    HA migrated it to a different node).
+    """
+    from app.services.cluster_registry import NoClustersConfigured, cluster_registry
+    from app.services.proxmox_client import get_pve
+
+    result = await db.execute(select(DriftEvent).where(DriftEvent.id == event_id))
+    event = result.scalar_one_or_none()
+    if not event:
+        raise HTTPException(status_code=404, detail="Drift event not found")
+    if event.drift_type not in AUTO_FIXABLE_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Drift type '{event.drift_type}' is not auto-fixable",
+        )
+    if not event.resource_id:
+        raise HTTPException(status_code=400, detail="Event has no associated resource")
+
+    resource_q = await db.execute(select(Resource).where(Resource.id == event.resource_id))
+    resource = resource_q.scalar_one_or_none()
+    if not resource:
+        raise HTTPException(status_code=404, detail="Associated resource no longer exists")
+    if not resource.proxmox_vmid:
+        raise HTTPException(status_code=400, detail="Resource has no proxmox_vmid")
+
+    if not cluster_registry.has_clusters():
+        await cluster_registry.reload()
+    try:
+        pve = get_pve()
+    except NoClustersConfigured as exc:
+        raise HTTPException(status_code=503, detail="No Proxmox cluster configured") from exc
+
+    try:
+        pve_resources = await asyncio.to_thread(pve.get_cluster_resources)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to query Proxmox: {exc}") from exc
+
+    pve_r = next(
+        (
+            r
+            for r in pve_resources
+            if r.get("type") in ("qemu", "lxc") and int(r.get("vmid", 0)) == resource.proxmox_vmid
+        ),
+        None,
+    )
+    if not pve_r:
+        raise HTTPException(
+            status_code=409,
+            detail="VMID no longer exists in Proxmox; this is now an orphaned_in_db event",
+        )
+
+    pve_status = _PVE_STATUS_MAP.get(pve_r.get("status", ""), "stopped")
+    pve_node = pve_r.get("node", "") or resource.proxmox_node
+
+    changes: dict[str, Any] = {}
+    if event.drift_type == "status_mismatch" and resource.status != pve_status:
+        changes["status"] = {"from": resource.status, "to": pve_status}
+        resource.status = pve_status
+    if event.drift_type == "node_mismatch" and pve_node and resource.proxmox_node != pve_node:
+        changes["proxmox_node"] = {"from": resource.proxmox_node, "to": pve_node}
+        resource.proxmox_node = pve_node
+
+    # Resolve the event by deleting it (next scan would do the same).
+    await db.delete(event)
+    await db.commit()
+    log.info("Drift event %s auto-fixed: %s", event_id, json.dumps(changes))
+    return {"id": str(event_id), "fixed": True, "changes": changes}
+
+
+@router.post("/fix-all")
+async def fix_all_auto_fixable(
+    _: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Auto-fix every active auto-fixable drift event by syncing DB to PVE."""
+    from app.services.cluster_registry import NoClustersConfigured, cluster_registry
+    from app.services.proxmox_client import get_pve
+
+    q = await db.execute(
+        select(DriftEvent).where(
+            DriftEvent.acknowledged.is_(False),
+            DriftEvent.drift_type.in_(list(AUTO_FIXABLE_TYPES)),
+            DriftEvent.resource_id.isnot(None),
+        )
+    )
+    events = list(q.scalars().all())
+    if not events:
+        return {"fixed": 0, "skipped": 0}
+
+    if not cluster_registry.has_clusters():
+        await cluster_registry.reload()
+    try:
+        pve = get_pve()
+    except NoClustersConfigured as exc:
+        raise HTTPException(status_code=503, detail="No Proxmox cluster configured") from exc
+    try:
+        pve_resources = await asyncio.to_thread(pve.get_cluster_resources)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to query Proxmox: {exc}") from exc
+
+    pve_by_vmid = {int(r["vmid"]): r for r in pve_resources if r.get("type") in ("qemu", "lxc")}
+
+    resource_ids = [e.resource_id for e in events if e.resource_id]
+    res_q = await db.execute(select(Resource).where(Resource.id.in_(resource_ids)))
+    resources_by_id = {r.id: r for r in res_q.scalars().all()}
+
+    fixed = 0
+    skipped = 0
+    for ev in events:
+        resource = resources_by_id.get(ev.resource_id)
+        if not resource or not resource.proxmox_vmid:
+            skipped += 1
+            continue
+        pve_r = pve_by_vmid.get(resource.proxmox_vmid)
+        if not pve_r:
+            skipped += 1
+            continue
+        pve_status = _PVE_STATUS_MAP.get(pve_r.get("status", ""), "stopped")
+        pve_node = pve_r.get("node", "") or resource.proxmox_node
+        changed = False
+        if ev.drift_type == "status_mismatch" and resource.status != pve_status:
+            resource.status = pve_status
+            changed = True
+        if ev.drift_type == "node_mismatch" and pve_node and resource.proxmox_node != pve_node:
+            resource.proxmox_node = pve_node
+            changed = True
+        if changed or resource.status == pve_status:
+            await db.delete(ev)
+            fixed += 1
+        else:
+            skipped += 1
+
+    await db.commit()
+    log.info("Drift fix-all: %d fixed, %d skipped", fixed, skipped)
+    return {"fixed": fixed, "skipped": skipped}
+
+
+@router.post("/{event_id}/acknowledge")
+async def acknowledge_drift_event(
+    event_id: uuid.UUID,
+    admin: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Mark a drift event as acknowledged."""
+    result = await db.execute(select(DriftEvent).where(DriftEvent.id == event_id))
+    event = result.scalar_one_or_none()
+    if not event:
+        raise HTTPException(status_code=404, detail="Drift event not found")
+    event.acknowledged = True
+    event.acknowledged_at = datetime.now(UTC)
+    event.acknowledged_by = admin.id
+    await db.commit()
+    return {"id": str(event.id), "acknowledged": True}
+
+
+@router.delete("/{event_id}")
+async def delete_drift_event(
+    event_id: uuid.UUID,
+    _: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    """Delete a single drift event."""
+    result = await db.execute(select(DriftEvent).where(DriftEvent.id == event_id))
+    event = result.scalar_one_or_none()
+    if not event:
+        raise HTTPException(status_code=404, detail="Drift event not found")
+    await db.delete(event)
+    await db.commit()
+    return {"detail": "Deleted"}

--- a/backend/app/routers/networking.py
+++ b/backend/app/routers/networking.py
@@ -21,6 +21,9 @@ from app.schemas.schemas import (
 )
 from app.services.audit_service import log_action
 from app.services.firewall_profile import FirewallProfileService
+from app.services.proxmox_cache import call_async as _pve_call
+from app.services.proxmox_cache import get_sdn_vnets as _cached_sdn_vnets
+from app.services.proxmox_cache import get_sdn_zones as _cached_sdn_zones
 from app.services.proxmox_client import get_pve
 
 router = APIRouter(prefix="/api/networking", tags=["networking"])
@@ -54,7 +57,7 @@ async def list_zones(
     _: User = Depends(get_current_active_user),
 ):
     try:
-        return get_pve(cluster_id).get_sdn_zones()
+        return await _cached_sdn_zones(cluster_id)
     except Exception as e:
         raise HTTPException(status_code=502, detail=str(e))
 
@@ -65,7 +68,7 @@ async def list_vnets(
     _: User = Depends(get_current_active_user),
 ):
     try:
-        return get_pve(cluster_id).get_sdn_vnets()
+        return await _cached_sdn_vnets(cluster_id)
     except Exception as e:
         raise HTTPException(status_code=502, detail=str(e))
 
@@ -83,7 +86,7 @@ async def create_vnet(
             kwargs["tag"] = body.tag
         if body.alias:
             kwargs["alias"] = body.alias
-        get_pve(cluster_id).create_sdn_vnet(body.name, body.zone, **kwargs)
+        await _pve_call(get_pve(cluster_id).create_sdn_vnet, body.name, body.zone, **kwargs)
         await log_action(db, user.id, "vnet_create", "network", details={"vnet": body.name, "zone": body.zone})
         return {"status": "created", "vnet": body.name}
     except Exception as e:
@@ -98,7 +101,7 @@ async def delete_vnet(
     user: User = Depends(require_admin),
 ):
     try:
-        get_pve(cluster_id).delete_sdn_vnet(vnet_name)
+        await _pve_call(get_pve(cluster_id).delete_sdn_vnet, vnet_name)
         await log_action(db, user.id, "vnet_delete", "network", details={"vnet": vnet_name})
     except Exception as e:
         raise HTTPException(status_code=502, detail=str(e))
@@ -115,7 +118,7 @@ async def get_firewall_rules(
     _: User = Depends(get_current_active_user),
 ):
     try:
-        return get_pve(cluster_id).get_firewall_rules(node, vmid, "qemu")
+        return await _pve_call(get_pve(cluster_id).get_firewall_rules, node, vmid, "qemu")
     except Exception as e:
         raise HTTPException(status_code=502, detail=str(e))
 
@@ -140,7 +143,7 @@ async def add_firewall_rule(
             if val is not None:
                 params[field] = val
 
-        get_pve(cluster_id).create_firewall_rule(node, vmid, "qemu", **params)
+        await _pve_call(get_pve(cluster_id).create_firewall_rule, node, vmid, "qemu", **params)
         await log_action(db, user.id, "firewall_add", "vm", details={"vmid": vmid, "rule": params})
         return {"status": "created"}
     except Exception as e:

--- a/backend/app/routers/proxmox.py
+++ b/backend/app/routers/proxmox.py
@@ -1,11 +1,15 @@
 """Proxmox cluster status endpoints (admin + user overview)."""
 
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.core.deps import get_current_active_user, require_admin
 from app.models.models import User
 from app.services.node_service import get_node_resources
-from app.services.proxmox_client import get_pve
+from app.services.proxmox_cache import get_cluster_status as cached_cluster_status
+from app.services.proxmox_cache import get_storage_list as cached_storage_list
+from app.services.proxmox_cache import get_vm_templates as cached_vm_templates
 
 router = APIRouter(prefix="/api/proxmox", tags=["proxmox"])
 
@@ -14,7 +18,7 @@ router = APIRouter(prefix="/api/proxmox", tags=["proxmox"])
 async def list_nodes(_: User = Depends(require_admin)):
     """Get cluster node status (admin only)."""
     try:
-        return get_node_resources()
+        return await asyncio.to_thread(get_node_resources)
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Failed to connect to Proxmox: {e}")
 
@@ -26,7 +30,7 @@ async def cluster_status(
 ):
     """Get cluster-level status (admin only)."""
     try:
-        return get_pve(cluster_id).get_cluster_status()
+        return await cached_cluster_status(cluster_id)
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Failed to connect to Proxmox: {e}")
 
@@ -38,7 +42,7 @@ async def list_templates(
 ):
     """List available VM templates."""
     try:
-        return get_pve(cluster_id).get_vm_templates()
+        return await cached_vm_templates(cluster_id)
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Failed to connect to Proxmox: {e}")
 
@@ -50,6 +54,6 @@ async def list_storage(
 ):
     """List storage pools (admin only)."""
     try:
-        return get_pve(cluster_id).get_storage_list()
+        return await cached_storage_list(cluster_id)
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Failed to connect to Proxmox: {e}")

--- a/backend/app/routers/resources.py
+++ b/backend/app/routers/resources.py
@@ -1,6 +1,7 @@
 """User-facing resource endpoints with tenant isolation."""
 
 import logging
+import re as _re
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -14,6 +15,7 @@ from app.core.pagination import PaginatedParams, PaginatedResponse
 from app.models.models import ProjectMember, Resource, User, UserQuota
 from app.schemas.schemas import QuotaRead, UsageResponse
 from app.services.group_access import check_group_access
+from app.services.proxmox_cache import get_cluster_resources as cached_cluster_resources
 from app.services.proxmox_client import get_pve
 
 logger = logging.getLogger(__name__)
@@ -76,17 +78,14 @@ async def list_my_resources(
     result = await db.execute(query)
     resources = list(result.scalars().all())
 
-    # Build VMID -> live info lookup from cluster resources (single API call per cluster)
+    # Build VMID -> live info lookup from cluster resources (single API call per cluster, cached)
     cluster_lookup: dict[int, dict] = {}
     cluster_ids = {r.cluster_id for r in resources if hasattr(r, "cluster_id")}
-    for cid in cluster_ids or {"default"}:
-        try:
-            for cr in get_pve(cid).get_cluster_resources("vm"):
-                vmid = cr.get("vmid")
-                if vmid is not None:
-                    cluster_lookup[vmid] = cr
-        except Exception:
-            pass
+    for cid in cluster_ids or {None}:
+        for cr in await cached_cluster_resources(cid, "vm"):
+            vmid = cr.get("vmid")
+            if vmid is not None:
+                cluster_lookup[vmid] = cr
 
     items = []
     for r in resources:
@@ -161,6 +160,19 @@ async def get_my_usage(
 
 # --- Resource Notes ---
 
+_PAWS_ID_RE = _re.compile(r"^PAWS-ID:([0-9a-f-]{36})", _re.MULTILINE)
+
+
+def parse_paws_id(description: str) -> str | None:
+    """Extract the PAWS resource UUID from a Proxmox description field.
+
+    Returns None if no PAWS-ID line is present.
+    """
+    if not description:
+        return None
+    m = _PAWS_ID_RE.search(description)
+    return m.group(1) if m else None
+
 
 def _build_paws_description(resource: Resource, owner: User | None, user_notes: str) -> str:
     """Build Proxmox description with PAWS metadata header + user notes."""
@@ -168,6 +180,8 @@ def _build_paws_description(resource: Resource, owner: User | None, user_notes: 
     email = (owner.email or "N/A") if owner else "N/A"
     owner_id = owner.id if owner else resource.owner_id
     lines = [
+        f"PAWS-ID:{resource.id}",
+        "",
         "PAWS Managed Resource",
         "",
         f"Owner: {username} ({email})",

--- a/backend/app/routers/security_groups.py
+++ b/backend/app/routers/security_groups.py
@@ -12,6 +12,7 @@ from app.core.database import get_db
 from app.core.deps import get_current_active_user
 from app.models.models import Resource, ResourceSecurityGroup, SecurityGroup, SecurityGroupRule, User
 from app.schemas.schemas import SecurityGroupCreate, SecurityGroupRead, SecurityGroupRuleCreate, SecurityGroupRuleRead
+from app.services.cluster_registry import NoClustersConfigured, cluster_registry
 
 router = APIRouter(prefix="/api/security-groups", tags=["security-groups"])
 
@@ -78,8 +79,6 @@ async def list_security_groups(
             )
             .options(selectinload(SecurityGroup.rules))
         )
-        if cluster_id:
-            query = query.where(SecurityGroup.cluster_id == cluster_id)
         result = await db.execute(query)
     else:
         query = (
@@ -88,8 +87,6 @@ async def list_security_groups(
             .options(selectinload(SecurityGroup.rules))
             .order_by(SecurityGroup.created_at.desc())
         )
-        if cluster_id:
-            query = query.where(SecurityGroup.cluster_id == cluster_id)
         result = await db.execute(query)
     return list(result.scalars().all())
 
@@ -100,17 +97,24 @@ async def create_security_group(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_active_user),
 ):
+    try:
+        _cluster_id = cluster_registry.default_cluster
+    except NoClustersConfigured:
+        raise HTTPException(
+            status_code=503, detail="No Proxmox cluster configured. Add one via Admin > Infrastructure."
+        )
+
     existing = await db.execute(
         select(SecurityGroup).where(
             SecurityGroup.owner_id == user.id,
             SecurityGroup.name == body.name,
-            SecurityGroup.cluster_id == body.cluster_id,
+            SecurityGroup.cluster_id == _cluster_id,
         )
     )
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Security group name already exists")
 
-    sg = SecurityGroup(owner_id=user.id, name=body.name, description=body.description, cluster_id=body.cluster_id)
+    sg = SecurityGroup(owner_id=user.id, name=body.name, description=body.description, cluster_id=_cluster_id)
     db.add(sg)
     await db.commit()
 
@@ -148,7 +152,12 @@ async def create_from_template(
     if template_id not in SG_TEMPLATES:
         raise HTTPException(status_code=404, detail=f"Template '{template_id}' not found")
 
-    cluster_id = body.cluster_id if body else "default"
+    try:
+        cluster_id = cluster_registry.default_cluster
+    except NoClustersConfigured:
+        raise HTTPException(
+            status_code=503, detail="No Proxmox cluster configured. Add one via Admin > Infrastructure."
+        )
     tpl = SG_TEMPLATES[template_id]
 
     existing = await db.execute(

--- a/backend/app/routers/storage_pools.py
+++ b/backend/app/routers/storage_pools.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.core.deps import get_current_active_user, require_admin
 from app.models.models import SystemSetting, User
-from app.services.proxmox_client import get_pve
+from app.services.proxmox_cache import get_storage_list as cached_storage_list
 
 router = APIRouter(prefix="/api/storage-pools", tags=["storage-pools"])
 
@@ -39,7 +39,7 @@ async def list_available_storage_pools(
 ):
     """Admin-only: list all Proxmox storages that can hold VM/container disks."""
     try:
-        storages = get_pve(cluster_id).get_storage_list()
+        storages = await cached_storage_list(cluster_id)
         result = []
         for s in storages:
             content = s.get("content", "")

--- a/backend/app/routers/vpcs.py
+++ b/backend/app/routers/vpcs.py
@@ -29,6 +29,7 @@ from app.models.models import (
 )
 from app.schemas.schemas import VPCCreate, VPCRead
 from app.services.audit_service import log_action
+from app.services.cluster_registry import NoClustersConfigured, cluster_registry
 from app.services.group_access import check_group_access
 from app.services.ipam_service import cidr_pool, ipam_service
 from app.services.proxmox_client import get_pve
@@ -290,7 +291,12 @@ async def create_vpc(
         )
 
     # VXLAN tag
-    cluster_id = body.cluster_id if hasattr(body, "cluster_id") else "default"
+    try:
+        cluster_id = cluster_registry.default_cluster
+    except NoClustersConfigured:
+        raise HTTPException(
+            status_code=503, detail="No Proxmox cluster configured. Add one via Admin > Infrastructure."
+        )
     tag = sdn_service.allocate_vxlan_tag(cluster_id=cluster_id)
 
     # Persist VPC (flush to obtain id before generating vnet name)

--- a/backend/app/services/cluster_registry.py
+++ b/backend/app/services/cluster_registry.py
@@ -7,13 +7,18 @@ Usage:
     pve = cluster_registry.get_pve()               # default (first) cluster
     pbs = cluster_registry.get_pbs("main")
     ids = cluster_registry.list_cluster_ids()
+
+Initialization:
+    Call ``await cluster_registry.reload()`` once during application startup
+    (FastAPI lifespan) and after any connection create/update/delete.
+    Celery tasks should call ``await cluster_registry.reload()`` inside their
+    async entry point if ``not cluster_registry.has_clusters()``.
 """
 
 import json
 import logging
 from dataclasses import dataclass, field
 
-from app.core.config import settings
 from app.services.pbs_client import PBSClient
 from app.services.proxmox_client import ProxmoxClient
 
@@ -38,12 +43,16 @@ class ClusterConfig:
     extra: dict = field(default_factory=dict)
 
 
-class NoClustersConfigured(RuntimeError):
+class NoClustersConfigured(RuntimeError):  # noqa: N818
     """Raised when a caller needs a Proxmox client but none are configured."""
 
 
 class ClusterRegistry:
-    """Manages ProxmoxClient + PBSClient instances for every configured cluster."""
+    """Manages ProxmoxClient + PBSClient instances for every configured cluster.
+
+    Clients are loaded asynchronously from the ``cluster_connections`` table.
+    Call ``await reload()`` at startup and after any connection CRUD.
+    """
 
     def __init__(self) -> None:
         self._pve_clients: dict[str, ProxmoxClient] = {}
@@ -53,68 +62,62 @@ class ClusterRegistry:
         self._initialized = False
 
     def _ensure_init(self) -> None:
-        if self._initialized:
-            return
-        self._initialized = True
+        """Guard used by sync accessors. Logs a warning if reload() was never called."""
+        if not self._initialized:
+            logger.warning(
+                "Cluster registry accessed before reload(). "
+                "Ensure await cluster_registry.reload() is called at startup."
+            )
+            self._initialized = True
 
-        if not self._load_from_db():
-            logger.warning("No Proxmox clusters configured. Add one via Admin > Infrastructure > Connections.")
+    async def reload(self) -> bool:
+        """Load (or reload) cluster connections from the database.
 
-    def _load_from_db(self) -> bool:
-        """Load cluster connections from the database (synchronous, for init)."""
+        Safe to call from FastAPI lifespan, async route handlers, and Celery tasks
+        that run their own event loop. Returns True if at least one PVE client
+        was registered.
+        """
+        self._pve_clients.clear()
+        self._pbs_clients.clear()
+        self._configs.clear()
+        self._default_cluster = None
+
         try:
-            from sqlalchemy import create_engine, text
+            from sqlalchemy import select
 
-            sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-            sync_url = sync_url.replace("postgresql+psycopg2", "postgresql")
-            engine = create_engine(sync_url)
+            from app.core.database import async_session
+            from app.core.encryption import decrypt
+            from app.models.models import ClusterConnection
 
-            with engine.connect() as conn:
-                # Check if table exists
-                row = conn.execute(
-                    text("SELECT 1 FROM information_schema.tables WHERE table_name = 'cluster_connections'")
-                ).fetchone()
-                if not row:
-                    return False
-
-                rows = conn.execute(
-                    text(
-                        "SELECT name, conn_type, host, port, token_id, "
-                        "token_secret_enc, password_enc, fingerprint, "
-                        "verify_ssl, is_active, extra_config, "
-                        "console_user, console_password_enc "
-                        "FROM cluster_connections WHERE is_active = true "
-                        "ORDER BY created_at"
-                    )
-                ).fetchall()
-
-            engine.dispose()
+            async with async_session() as db:
+                result = await db.execute(
+                    select(ClusterConnection)
+                    .where(ClusterConnection.is_active.is_(True))
+                    .order_by(ClusterConnection.created_at)
+                )
+                rows = result.scalars().all()
 
             if not rows:
+                logger.warning("No active cluster connections found. Add one via Admin > Infrastructure > Connections.")
+                self._initialized = True
                 return False
 
-            from app.core.encryption import decrypt
-
-            for r in rows:
-                name = r[0]
-                conn_type = r[1]
-                host = r[2]
-                port = r[3]
-                token_id = r[4] or ""
-                token_secret = decrypt(r[5]) if r[5] else ""
-                password = decrypt(r[6]) if r[6] else ""
-                fingerprint = r[7] or ""
-                verify_ssl = r[8]
-                extra = json.loads(r[10]) if r[10] else {}
-                console_user = r[11] or ""
-                console_password = decrypt(r[12]) if r[12] else ""
+            for conn in rows:
+                name = conn.name
+                conn_type = conn.conn_type
+                host = conn.host
+                port = conn.port
+                token_id = conn.token_id or ""
+                token_secret = decrypt(conn.token_secret_enc) if conn.token_secret_enc else ""
+                password = decrypt(conn.password_enc) if conn.password_enc else ""
+                fingerprint = conn.fingerprint or ""
+                verify_ssl = conn.verify_ssl
+                extra = json.loads(conn.extra_config) if conn.extra_config else {}
+                console_user = conn.console_user or ""
+                console_password = decrypt(conn.console_password_enc) if conn.console_password_enc else ""
 
                 if conn_type == "pve":
-                    cfg = ClusterConfig(
-                        name=name,
-                        host=host,
-                        port=port,
-                    )
+                    cfg = ClusterConfig(name=name, host=host, port=port)
                     self._configs[name] = cfg
                     self._pve_clients[name] = ProxmoxClient(
                         host=host,
@@ -129,11 +132,10 @@ class ClusterRegistry:
                     )
                     if self._default_cluster is None:
                         self._default_cluster = name
-                    logger.info("Registered PVE cluster '%s' from DB (%s:%d)", name, host, port)
+                    logger.info("Registered PVE cluster '%s' (%s:%d)", name, host, port)
 
                 elif conn_type == "pbs":
                     datastore = extra.get("datastore", "backups")
-                    # Find matching PVE cluster name or use PBS name
                     pve_cluster = extra.get("pve_cluster", name)
                     self._pbs_clients[pve_cluster] = PBSClient(
                         host=host,
@@ -145,27 +147,19 @@ class ClusterRegistry:
                         verify_ssl=verify_ssl,
                         cluster_name=pve_cluster,
                     )
-                    # Annotate matching PVE config with PBS endpoint for admin views
                     if pve_cluster in self._configs:
                         self._configs[pve_cluster].pbs_host = host
                         self._configs[pve_cluster].pbs_port = port
                         self._configs[pve_cluster].pbs_datastore = datastore
-                    logger.info("Registered PBS '%s' from DB (%s:%d)", name, host, port)
-
-            return bool(self._pve_clients)
+                    logger.info("Registered PBS '%s' (%s:%d)", name, host, port)
 
         except Exception as exc:
-            logger.debug("DB cluster load skipped: %s", exc)
+            logger.error("Cluster registry reload failed: %s", exc)
+            self._initialized = True
             return False
 
-    def invalidate(self) -> None:
-        """Clear all cached clients, forcing reload on next access."""
-        self._pve_clients.clear()
-        self._pbs_clients.clear()
-        self._configs.clear()
-        self._default_cluster = None
-        self._initialized = False
-        logger.info("Cluster registry invalidated, will reload on next access")
+        self._initialized = True
+        return bool(self._pve_clients)
 
     @property
     def default_cluster(self) -> str:

--- a/backend/app/services/proxmox_cache.py
+++ b/backend/app/services/proxmox_cache.py
@@ -1,0 +1,191 @@
+"""Async + Redis-cached wrappers around the synchronous proxmoxer client.
+
+The proxmoxer library is built on `requests` (sync). Calling it directly inside
+a FastAPI ``async def`` handler blocks the entire event loop for the duration
+of the HTTPS round-trip to Proxmox (~200 ms - 2 s each), which serializes ALL
+concurrent requests including pure-DB endpoints like ``/quota``.
+
+Every router that needs Proxmox data on the request path should go through
+this module. It does two things:
+
+1. Wraps the sync call in :func:`asyncio.to_thread` so the event loop stays
+   responsive.
+2. Caches the result in Redis with a short TTL so back-to-back page loads do
+   not all hit Proxmox.
+
+Hot reads also have Celery beat warmers in :mod:`app.tasks.cache_refresh` so
+the first user request after a cache expiry typically still hits a warm key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from app.services.cache import cached_call
+from app.services.cluster_registry import NoClustersConfigured, cluster_registry
+from app.services.proxmox_client import get_pve
+
+logger = logging.getLogger(__name__)
+
+
+CLUSTER_RESOURCES_TTL = 15
+NODES_TTL = 15
+CLUSTER_STATUS_TTL = 15
+TEMPLATES_TTL = 60
+STORAGE_LIST_TTL = 60
+SDN_ZONES_TTL = 60
+SDN_VNETS_TTL = 30
+
+
+def _resolve_cluster_id(cluster_id: str | None) -> str:
+    """Return the resolved cluster id for cache keying. Falls back to 'default'."""
+    if cluster_id:
+        return cluster_id
+    try:
+        return cluster_registry.default_cluster or "default"
+    except NoClustersConfigured:
+        return "default"
+
+
+async def get_cluster_resources(cluster_id: str | None = None, resource_type: str | None = None) -> list[dict]:
+    """Cached + async wrapper around ``pve.get_cluster_resources``.
+
+    Returns ``[]`` on Proxmox failure or no clusters configured (callers should
+    treat as "live data unavailable" rather than fatal error).
+    """
+    cid = _resolve_cluster_id(cluster_id)
+    key = f"pve:{cid}:cluster_resources:{resource_type or 'all'}"
+
+    async def _produce() -> list[dict]:
+        try:
+            pve = get_pve(cluster_id)
+            return await asyncio.to_thread(pve.get_cluster_resources, resource_type)
+        except NoClustersConfigured:
+            return []
+        except Exception as exc:
+            logger.warning("get_cluster_resources(%s, %s) failed: %s", cid, resource_type, exc)
+            return []
+
+    return await cached_call(key, CLUSTER_RESOURCES_TTL, _produce)
+
+
+async def get_vm_status_map(cluster_id: str | None = None) -> dict[int, dict]:
+    """Return a vmid -> status dict for all VMs/LXCs in the cluster.
+
+    Backed by :func:`get_cluster_resources` so it shares its cache.
+    """
+    resources = await get_cluster_resources(cluster_id)
+    return {r["vmid"]: r for r in resources if r.get("vmid") and r.get("type") in ("qemu", "lxc")}
+
+
+async def get_nodes(cluster_id: str | None = None) -> list[dict]:
+    cid = _resolve_cluster_id(cluster_id)
+    key = f"pve:{cid}:nodes"
+
+    async def _produce() -> list[dict]:
+        try:
+            pve = get_pve(cluster_id)
+            return await asyncio.to_thread(pve.get_nodes)
+        except NoClustersConfigured:
+            return []
+        except Exception as exc:
+            logger.warning("get_nodes(%s) failed: %s", cid, exc)
+            return []
+
+    return await cached_call(key, NODES_TTL, _produce)
+
+
+async def get_cluster_status(cluster_id: str | None = None) -> list[dict]:
+    cid = _resolve_cluster_id(cluster_id)
+    key = f"pve:{cid}:cluster_status"
+
+    async def _produce() -> list[dict]:
+        try:
+            pve = get_pve(cluster_id)
+            return await asyncio.to_thread(pve.get_cluster_status)
+        except NoClustersConfigured:
+            return []
+        except Exception as exc:
+            logger.warning("get_cluster_status(%s) failed: %s", cid, exc)
+            return []
+
+    return await cached_call(key, CLUSTER_STATUS_TTL, _produce)
+
+
+async def get_vm_templates(cluster_id: str | None = None) -> list[dict]:
+    cid = _resolve_cluster_id(cluster_id)
+    key = f"pve:{cid}:templates"
+
+    async def _produce() -> list[dict]:
+        try:
+            pve = get_pve(cluster_id)
+            return await asyncio.to_thread(pve.get_vm_templates)
+        except NoClustersConfigured:
+            return []
+        except Exception as exc:
+            logger.warning("get_vm_templates(%s) failed: %s", cid, exc)
+            return []
+
+    return await cached_call(key, TEMPLATES_TTL, _produce)
+
+
+async def get_storage_list(cluster_id: str | None = None) -> list[dict]:
+    cid = _resolve_cluster_id(cluster_id)
+    key = f"pve:{cid}:storage_list"
+
+    async def _produce() -> list[dict]:
+        try:
+            pve = get_pve(cluster_id)
+            return await asyncio.to_thread(pve.get_storage_list)
+        except NoClustersConfigured:
+            return []
+        except Exception as exc:
+            logger.warning("get_storage_list(%s) failed: %s", cid, exc)
+            return []
+
+    return await cached_call(key, STORAGE_LIST_TTL, _produce)
+
+
+async def get_sdn_zones(cluster_id: str | None = None) -> list[dict]:
+    cid = _resolve_cluster_id(cluster_id)
+    key = f"pve:{cid}:sdn_zones"
+
+    async def _produce() -> list[dict]:
+        try:
+            pve = get_pve(cluster_id)
+            return await asyncio.to_thread(pve.get_sdn_zones)
+        except NoClustersConfigured:
+            return []
+        except Exception as exc:
+            logger.warning("get_sdn_zones(%s) failed: %s", cid, exc)
+            return []
+
+    return await cached_call(key, SDN_ZONES_TTL, _produce)
+
+
+async def get_sdn_vnets(cluster_id: str | None = None) -> list[dict]:
+    cid = _resolve_cluster_id(cluster_id)
+    key = f"pve:{cid}:sdn_vnets"
+
+    async def _produce() -> list[dict]:
+        try:
+            pve = get_pve(cluster_id)
+            return await asyncio.to_thread(pve.get_sdn_vnets)
+        except NoClustersConfigured:
+            return []
+        except Exception as exc:
+            logger.warning("get_sdn_vnets(%s) failed: %s", cid, exc)
+            return []
+
+    return await cached_call(key, SDN_VNETS_TTL, _produce)
+
+
+async def call_async(fn, *args: Any, **kwargs: Any) -> Any:
+    """Generic ``asyncio.to_thread`` wrapper for ad-hoc proxmoxer calls.
+
+    Use this for write/mutating calls that should not be cached but still
+    must not block the event loop, e.g. ``await call_async(pve.create_sdn_vnet, name, zone)``.
+    """
+    return await asyncio.to_thread(fn, *args, **kwargs)

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -1,1 +1,5 @@
-# PAWS Celery task modules - autodiscovered by worker.py
+# PAWS Celery task modules - imported here so that autodiscover_tasks(["app.tasks"])
+# in app.worker registers every @shared_task decorated function. Without these
+# imports, Celery's default related_name="tasks" would look for app.tasks.tasks
+# (which does not exist) and silently register nothing.
+from app.tasks import cache_refresh, drift_scanner, email_tasks, resource_lifecycle  # noqa: F401

--- a/backend/app/tasks/_async_runner.py
+++ b/backend/app/tasks/_async_runner.py
@@ -1,0 +1,40 @@
+"""Run async coroutines from sync Celery tasks with a fresh DB engine per call.
+
+Celery prefork workers create a brand-new asyncio event loop on every task
+invocation. The application-wide SQLAlchemy ``engine`` keeps an asyncpg
+connection pool whose ``Future`` wakeups are bound to whichever loop first
+touched them, so the *second* task that runs in a worker explodes with
+``RuntimeError: ... attached to a different loop``.
+
+To keep task code unchanged (it just does ``from app.core.database import
+async_session``), this helper monkey-patches ``app.core.database.engine`` and
+``async_session`` to a fresh ``NullPool`` engine for the lifetime of the call,
+then disposes it and restores the originals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def run_task_async(coro):
+    from app.core import database as db_module
+
+    async def _runner():
+        task_engine, task_session = db_module.make_task_session_factory()
+        original_engine = db_module.engine
+        original_session = db_module.async_session
+        db_module.engine = task_engine
+        db_module.async_session = task_session
+        try:
+            return await coro
+        finally:
+            db_module.engine = original_engine
+            db_module.async_session = original_session
+            await task_engine.dispose()
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_runner())
+    finally:
+        loop.close()

--- a/backend/app/tasks/cache_refresh.py
+++ b/backend/app/tasks/cache_refresh.py
@@ -5,6 +5,8 @@ import logging
 
 from celery import shared_task
 
+from app.services.cache import cache_set
+
 log = logging.getLogger(__name__)
 
 
@@ -18,7 +20,7 @@ def _run_async(coro):
 
 
 async def _refresh_cluster_status_cache() -> dict:
-    """Re-compute ``cluster_status`` for every registered cluster and push into Redis.
+    """Re-compute ``cluster_status`` for the primary cluster and push into Redis.
 
     This deliberately bypasses the normal lazy-cache read; we compute and then
     force-write the result so the next user request is guaranteed to hit a warm
@@ -26,29 +28,65 @@ async def _refresh_cluster_status_cache() -> dict:
     payload but do not raise.
     """
     from app.routers.cluster import CLUSTER_STATUS_TTL_SECONDS, _compute_cluster_status
-    from app.services.cache import cache_set
-    from app.services.cluster_registry import cluster_registry
+    from app.services.cluster_registry import NoClustersConfigured, cluster_registry
 
-    refreshed: list[str] = []
-    errors: list[str] = []
+    if not cluster_registry.has_clusters():
+        await cluster_registry.reload()
 
-    cluster_ids = cluster_registry.list_cluster_ids()
-    if not cluster_ids:
+    if not cluster_registry.list_cluster_ids():
         return {"refreshed": [], "errors": []}
 
-    for cid in cluster_ids:
-        try:
-            payload = await _compute_cluster_status(cid)
-            await cache_set(f"cluster_status:{cid}", payload, CLUSTER_STATUS_TTL_SECONDS)
-            refreshed.append(cid)
-        except Exception as exc:
-            log.warning("cluster_status refresh failed for %s: %s", cid, exc)
-            errors.append(cid)
-
-    return {"refreshed": refreshed, "errors": errors}
+    try:
+        payload = await _compute_cluster_status()
+        await cache_set("cluster_status", payload, CLUSTER_STATUS_TTL_SECONDS)
+        return {"refreshed": ["primary"], "errors": []}
+    except NoClustersConfigured:
+        return {"refreshed": [], "errors": []}
+    except Exception as exc:
+        log.warning("cluster_status refresh failed: %s", exc)
+        return {"refreshed": [], "errors": ["primary"]}
 
 
 @shared_task(name="paws.refresh_cluster_status_cache")
 def refresh_cluster_status_cache():
     """Celery-scheduled entry point for cluster status cache warming."""
     return _run_async(_refresh_cluster_status_cache())
+
+
+async def _refresh_vm_statuses_batch() -> dict:
+    """Force-refresh the shared cluster_resources caches used by list pages.
+
+    Beat runs this faster than the cache TTL so user requests almost always
+    hit warm Redis and never block the event loop on a sync Proxmox call.
+    """
+    import asyncio as _asyncio
+
+    from app.services.cache import cache_set
+    from app.services.cluster_registry import NoClustersConfigured, cluster_registry
+    from app.services.proxmox_cache import CLUSTER_RESOURCES_TTL, _resolve_cluster_id
+    from app.services.proxmox_client import get_pve
+
+    if not cluster_registry.has_clusters():
+        await cluster_registry.reload()
+    if not cluster_registry.has_clusters():
+        return {"refreshed": False}
+
+    try:
+        pve = get_pve()
+        cid = _resolve_cluster_id(None)
+        all_resources = await _asyncio.to_thread(pve.get_cluster_resources, None)
+        vm_resources = [r for r in all_resources if r.get("type") == "qemu"]
+        await cache_set(f"pve:{cid}:cluster_resources:all", all_resources, CLUSTER_RESOURCES_TTL)
+        await cache_set(f"pve:{cid}:cluster_resources:vm", vm_resources, CLUSTER_RESOURCES_TTL)
+        return {"refreshed": True, "all": len(all_resources), "vm": len(vm_resources)}
+    except NoClustersConfigured:
+        return {"refreshed": False}
+    except Exception as exc:
+        log.warning("vm_statuses_batch refresh failed: %s", exc)
+        return {"refreshed": False, "error": str(exc)}
+
+
+@shared_task(name="paws.refresh_vm_statuses_batch")
+def refresh_vm_statuses_batch():
+    """Celery-scheduled entry point for batch VM status cache warming."""
+    return _run_async(_refresh_vm_statuses_batch())

--- a/backend/app/tasks/drift_scanner.py
+++ b/backend/app/tasks/drift_scanner.py
@@ -1,0 +1,191 @@
+"""Background drift scanner: detects divergence between the PAWS DB and Proxmox cluster.
+
+Runs every 5 minutes via Celery Beat. Records findings in the drift_events table.
+Previous unacknowledged events of the same type+resource are replaced on each scan
+to avoid unbounded growth.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from celery import shared_task
+
+log = logging.getLogger(__name__)
+
+_PVE_STATUS_MAP = {
+    "running": "running",
+    "stopped": "stopped",
+    "paused": "stopped",
+    "suspended": "stopped",
+}
+
+
+def _run_async(coro):
+    from app.tasks._async_runner import run_task_async
+
+    return run_task_async(coro)
+
+
+async def _scan() -> dict:
+    import uuid
+
+    from sqlalchemy import select
+
+    from app.core.database import async_session
+    from app.models.models import DriftEvent, Resource
+    from app.routers.resources import parse_paws_id
+    from app.services.cluster_registry import NoClustersConfigured, cluster_registry
+    from app.services.proxmox_client import get_pve
+
+    if not cluster_registry.has_clusters():
+        await cluster_registry.reload()
+
+    try:
+        pve = get_pve()
+    except NoClustersConfigured:
+        log.debug("Drift scan skipped: no cluster configured")
+        return {"skipped": True}
+
+    try:
+        pve_resources = pve.get_cluster_resources()
+    except Exception as exc:
+        log.warning("Drift scan: failed to list Proxmox resources: %s", exc)
+        return {"error": str(exc)}
+
+    pve_by_vmid: dict[int, dict] = {}
+    for r in pve_resources:
+        if r.get("type") in ("qemu", "lxc"):
+            pve_by_vmid[int(r["vmid"])] = r
+
+    async with async_session() as db:
+        result = await db.execute(
+            select(Resource).where(
+                Resource.resource_type.in_(["vm", "lxc"]),
+                Resource.status.notin_(["deleted", "terminated", "error"]),
+                Resource.proxmox_vmid.isnot(None),
+            )
+        )
+        db_resources = list(result.scalars().all())
+
+        db_vmids = {r.proxmox_vmid for r in db_resources}
+        pve_vmids = set(pve_by_vmid.keys())
+
+        events_to_upsert: list[dict] = []
+        auto_fixed = 0
+
+        for r in db_resources:
+            if r.proxmox_vmid not in pve_vmids:
+                events_to_upsert.append(
+                    {
+                        "resource_id": str(r.id),
+                        "proxmox_vmid": r.proxmox_vmid,
+                        "proxmox_node": r.proxmox_node,
+                        "drift_type": "orphaned_in_db",
+                        "details": json.dumps({"db_status": r.status, "db_node": r.proxmox_node}),
+                    }
+                )
+
+        for r in db_resources:
+            pve_r = pve_by_vmid.get(r.proxmox_vmid)
+            if not pve_r:
+                continue
+            pve_status = _PVE_STATUS_MAP.get(pve_r.get("status", ""), "stopped")
+            pve_node = pve_r.get("node", "")
+
+            # Auto-correct status_mismatch by syncing DB to PVE (PVE is source of truth).
+            if r.status in ("running", "stopped") and r.status != pve_status:
+                log.info(
+                    "Drift auto-fix status_mismatch: resource=%s vmid=%s db=%s -> pve=%s",
+                    r.id,
+                    r.proxmox_vmid,
+                    r.status,
+                    pve_status,
+                )
+                r.status = pve_status
+                auto_fixed += 1
+
+            # Auto-correct node_mismatch (e.g., after live migration) by syncing DB to PVE.
+            if r.proxmox_node and pve_node and r.proxmox_node != pve_node:
+                log.info(
+                    "Drift auto-fix node_mismatch: resource=%s vmid=%s db=%s -> pve=%s",
+                    r.id,
+                    r.proxmox_vmid,
+                    r.proxmox_node,
+                    pve_node,
+                )
+                r.proxmox_node = pve_node
+                auto_fixed += 1
+
+        for vmid, pve_r in pve_by_vmid.items():
+            if vmid in db_vmids:
+                continue
+            desc = pve_r.get("description") or pve_r.get("notes") or ""
+            paws_id = parse_paws_id(desc)
+            if paws_id:
+                events_to_upsert.append(
+                    {
+                        "resource_id": None,
+                        "proxmox_vmid": vmid,
+                        "proxmox_node": pve_r.get("node"),
+                        "drift_type": "orphaned_in_proxmox",
+                        "details": json.dumps({"paws_id": paws_id, "pve_name": pve_r.get("name", "")}),
+                    }
+                )
+
+        now = datetime.now(UTC)
+        inserted = 0
+        resolved = 0
+
+        current_event_keys = {(e["resource_id"], e["drift_type"]) for e in events_to_upsert}
+
+        existing_result = await db.execute(select(DriftEvent).where(DriftEvent.acknowledged.is_(False)))
+        for existing in existing_result.scalars().all():
+            key = (str(existing.resource_id) if existing.resource_id else None, existing.drift_type)
+            if key not in current_event_keys:
+                await db.delete(existing)
+                resolved += 1
+
+        for ev in events_to_upsert:
+            existing_q = await db.execute(
+                select(DriftEvent).where(
+                    DriftEvent.drift_type == ev["drift_type"],
+                    DriftEvent.acknowledged.is_(False),
+                    DriftEvent.resource_id == (uuid.UUID(ev["resource_id"]) if ev["resource_id"] else None),
+                )
+            )
+            existing_event = existing_q.scalar_one_or_none()
+            if existing_event:
+                existing_event.detected_at = now
+                existing_event.proxmox_vmid = ev["proxmox_vmid"]
+                existing_event.proxmox_node = ev["proxmox_node"]
+                existing_event.details = ev["details"]
+            else:
+                new_event = DriftEvent(
+                    id=uuid.uuid4(),
+                    detected_at=now,
+                    resource_id=uuid.UUID(ev["resource_id"]) if ev["resource_id"] else None,
+                    proxmox_vmid=ev["proxmox_vmid"],
+                    proxmox_node=ev["proxmox_node"],
+                    drift_type=ev["drift_type"],
+                    details=ev["details"],
+                    acknowledged=False,
+                )
+                db.add(new_event)
+                inserted += 1
+
+        await db.commit()
+        log.info(
+            "Drift scan complete: %d new events, %d resolved, %d auto-fixed",
+            inserted,
+            resolved,
+            auto_fixed,
+        )
+        return {"inserted": inserted, "resolved": resolved, "auto_fixed": auto_fixed}
+
+
+@shared_task(name="paws.scan_drift")
+def scan_drift():
+    return _run_async(_scan())

--- a/backend/app/tasks/email_tasks.py
+++ b/backend/app/tasks/email_tasks.py
@@ -1,6 +1,5 @@
 """Celery tasks for sending email notifications."""
 
-import asyncio
 import logging
 from typing import Any
 
@@ -10,22 +9,19 @@ log = logging.getLogger(__name__)
 
 
 def _run_async(coro):  # noqa: ANN001
-    """Run an async coroutine from a sync Celery task."""
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
+    from app.tasks._async_runner import run_task_async
+
+    return run_task_async(coro)
 
 
 async def _send_notification(user_id: str, template_name: str, context: dict[str, Any]) -> None:
     from sqlalchemy import select
 
-    from app.core.database import async_session_factory
+    from app.core.database import async_session
     from app.models.models import User
     from app.services.email_service import send_template_email
 
-    async with async_session_factory() as db:
+    async with async_session() as db:
         result = await db.execute(select(User).where(User.id == user_id))
         user = result.scalar_one_or_none()
         if not user:

--- a/backend/app/tasks/resource_lifecycle.py
+++ b/backend/app/tasks/resource_lifecycle.py
@@ -1,6 +1,5 @@
 """Periodic tasks: enforce resource and account lifecycle policies."""
 
-import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
 
@@ -10,23 +9,20 @@ log = logging.getLogger(__name__)
 
 
 def _run_async(coro):
-    """Run an async coroutine from a sync Celery task."""
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
+    from app.tasks._async_runner import run_task_async
+
+    return run_task_async(coro)
 
 
 async def _enforce_lifecycle():
     from sqlalchemy import select
     from sqlalchemy.orm import selectinload
 
-    from app.core.database import async_session_factory
+    from app.core.database import async_session
     from app.models.models import Resource, SystemSetting, User
     from app.services.proxmox_client import get_pve
 
-    async with async_session_factory() as db:
+    async with async_session() as db:
         result = await db.execute(
             select(SystemSetting).where(SystemSetting.key.in_(["idle_shutdown_days", "idle_destroy_days"]))
         )
@@ -133,11 +129,11 @@ async def _enforce_account_lifecycle():
     from sqlalchemy import select
     from sqlalchemy.orm import selectinload
 
-    from app.core.database import async_session_factory
+    from app.core.database import async_session
     from app.models.models import SystemSetting, User
     from app.services.user_cleanup import purge_user
 
-    async with async_session_factory() as db:
+    async with async_session() as db:
         result = await db.execute(select(SystemSetting).where(SystemSetting.key == "account_inactive_days"))
         setting = result.scalar_one_or_none()
         default_inactive = int(setting.value if setting else "0")
@@ -190,11 +186,11 @@ async def _enforce_quota():
 
     from sqlalchemy import select
 
-    from app.core.database import async_session_factory
+    from app.core.database import async_session
     from app.models.models import Resource, User, UserQuota
     from app.services.proxmox_client import get_pve
 
-    async with async_session_factory() as db:
+    async with async_session() as db:
         # Get all users with running resources
         result = await db.execute(
             select(Resource.owner_id)

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -34,6 +34,14 @@ celery_app.conf.update(
             "task": "paws.refresh_cluster_status_cache",
             "schedule": 30.0,  # every 30 seconds - keeps dashboard warm
         },
+        "refresh-vm-statuses-batch": {
+            "task": "paws.refresh_vm_statuses_batch",
+            "schedule": 10.0,  # every 10 seconds - keeps list pages warm
+        },
+        "scan-drift": {
+            "task": "paws.scan_drift",
+            "schedule": 300.0,  # every 5 minutes
+        },
     },
 )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "aioboto3>=13.0.0",
     "aiosmtplib>=3.0.0",
     "bcrypt>=4.0.0",
+    "prometheus-fastapi-instrumentator>=7.0.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/seeds/instance_types.yml
+++ b/backend/seeds/instance_types.yml
@@ -1,0 +1,98 @@
+# PAWS default instance types. Edit this file to customize available sizes.
+# Fields: name, vcpus, ram_mib, disk_gib, category, description, sort_order
+instance_types:
+  - name: paws.nano
+    vcpus: 1
+    ram_mib: 512
+    disk_gib: 10
+    category: general
+    description: "Nano - 1 vCPU, 512 MiB RAM, 10 GiB"
+    sort_order: 10
+
+  - name: paws.micro
+    vcpus: 1
+    ram_mib: 1024
+    disk_gib: 20
+    category: general
+    description: "Micro - 1 vCPU, 1 GiB RAM, 20 GiB"
+    sort_order: 20
+
+  - name: paws.small
+    vcpus: 2
+    ram_mib: 2048
+    disk_gib: 40
+    category: general
+    description: "Small - 2 vCPU, 2 GiB RAM, 40 GiB"
+    sort_order: 30
+
+  - name: paws.medium
+    vcpus: 2
+    ram_mib: 4096
+    disk_gib: 80
+    category: general
+    description: "Medium - 2 vCPU, 4 GiB RAM, 80 GiB"
+    sort_order: 40
+
+  - name: paws.large
+    vcpus: 4
+    ram_mib: 8192
+    disk_gib: 160
+    category: general
+    description: "Large - 4 vCPU, 8 GiB RAM, 160 GiB"
+    sort_order: 50
+
+  - name: paws.xlarge
+    vcpus: 8
+    ram_mib: 16384
+    disk_gib: 320
+    category: general
+    description: "XLarge - 8 vCPU, 16 GiB RAM, 320 GiB"
+    sort_order: 60
+
+  - name: paws.compute.small
+    vcpus: 4
+    ram_mib: 2048
+    disk_gib: 40
+    category: compute
+    description: "Compute Small - 4 vCPU, 2 GiB RAM"
+    sort_order: 110
+
+  - name: paws.compute.medium
+    vcpus: 8
+    ram_mib: 4096
+    disk_gib: 40
+    category: compute
+    description: "Compute Medium - 8 vCPU, 4 GiB RAM"
+    sort_order: 120
+
+  - name: paws.compute.large
+    vcpus: 16
+    ram_mib: 8192
+    disk_gib: 40
+    category: compute
+    description: "Compute Large - 16 vCPU, 8 GiB RAM"
+    sort_order: 130
+
+  - name: paws.memory.small
+    vcpus: 2
+    ram_mib: 8192
+    disk_gib: 40
+    category: memory
+    description: "Memory Small - 2 vCPU, 8 GiB RAM"
+    sort_order: 210
+
+  - name: paws.memory.medium
+    vcpus: 4
+    ram_mib: 16384
+    disk_gib: 80
+    category: memory
+    description: "Memory Medium - 4 vCPU, 16 GiB RAM"
+    sort_order: 220
+
+  - name: paws.memory.large
+    vcpus: 8
+    ram_mib: 32768
+    disk_gib: 160
+    category: memory
+    description: "Memory Large - 8 vCPU, 32 GiB RAM"
+    sort_order: 230

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -88,6 +88,27 @@ class MockProxmoxClient:
     _console_password = ""
     cluster_name = "default"
 
+    def __init__(self) -> None:
+        # Track VMs/containers created via clone_vm/create_vm so that
+        # get_cluster_resources() returns them (needed for batch status lookup).
+        self._created_vms: dict[int, dict[str, Any]] = {}
+
+    def _register_vm(self, vmid: int, node: str, vm_type: str = "qemu") -> None:
+        self._created_vms[vmid] = {
+            "vmid": vmid,
+            "type": vm_type,
+            "status": "running",
+            "cpu": 0.05,
+            "mem": 512 * 1024**2,
+            "maxmem": 2048 * 1024**2,
+            "uptime": 1234,
+            "netin": 0,
+            "netout": 0,
+            "disk": 0,
+            "maxdisk": 32 * 1024**3,
+            "node": node,
+        }
+
     @property
     def api(self):
         """Chainable mock for raw proxmoxer API access (e.g. api.nodes(x).qemu(y).firewall.rules.get())."""
@@ -126,15 +147,20 @@ class MockProxmoxClient:
         return [{"type": "cluster", "name": "paws-cluster", "nodes": 2, "quorate": 1}]
 
     def get_cluster_resources(self, resource_type: str | None = None) -> list[dict[str, Any]]:
-        return []
+        resources = list(self._created_vms.values())
+        if resource_type:
+            resources = [r for r in resources if r.get("type") == resource_type]
+        return resources
 
     def clone_vm(self, node: str, source_vmid: int, new_vmid: int, **kw: Any) -> str:
+        self._register_vm(new_vmid, node, "qemu")
         return f"UPID:{node}:00001234:00AB12CD:clonevm:{new_vmid}:user@pam:"
 
     def get_next_vmid(self) -> int:
         return 500
 
     def create_vm(self, node: str, vmid: int, **kw: Any) -> str:
+        self._register_vm(vmid, node, "qemu")
         return f"UPID:{node}:00001234:00AB12CD:createvm:{vmid}:user@pam:"
 
     def get_vm_status(self, node: str, vmid: int) -> dict[str, Any]:
@@ -174,6 +200,7 @@ class MockProxmoxClient:
         pass
 
     def create_container(self, node: str, vmid: int, **kw: Any) -> str:
+        self._register_vm(vmid, node, "lxc")
         return f"UPID:{node}:createct:{vmid}"
 
     def get_container_status(self, node: str, vmid: int) -> dict[str, Any]:
@@ -309,6 +336,7 @@ class MockProxmoxClient:
         return True
 
     def clone_container(self, node: str, source_vmid: int, new_vmid: int, **kw: Any) -> str:
+        self._register_vm(new_vmid, node, "lxc")
         return f"UPID:{node}:00001234:00AB12CD:clonect:{new_vmid}:user@pam:"
 
     def wait_for_task(self, node: str, upid: str, timeout: int = 300) -> dict[str, Any]:
@@ -421,7 +449,7 @@ mock_storage = MockStorageService()
 
 @pytest.fixture
 def mock_proxmox_client():
-    return mock_proxmox
+    return MockProxmoxClient()
 
 
 @pytest.fixture
@@ -506,8 +534,11 @@ async def client(db_session: AsyncSession, monkeypatch) -> AsyncGenerator[AsyncC
     import app.services.rate_limiter as rl_mod
     import app.services.storage_service as stg_mod
 
+    # Fresh mock per test so _created_vms state doesn't bleed between tests
+    test_proxmox = MockProxmoxClient()
+
     # Swap singletons / proxies
-    monkeypatch.setattr(pxm_mod, "proxmox_client", mock_proxmox)
+    monkeypatch.setattr(pxm_mod, "proxmox_client", test_proxmox)
     monkeypatch.setattr(stg_mod, "storage_service", mock_storage)
     monkeypatch.setattr(rl_mod, "check_action_rate_limit", _always_allow)
     monkeypatch.setattr(rl_mod, "check_api_rate_limit", _always_allow_api)
@@ -516,8 +547,8 @@ async def client(db_session: AsyncSession, monkeypatch) -> AsyncGenerator[AsyncC
     # Patch cluster registry so get_pve() / get_pbs() return mocks
     monkeypatch.setattr(reg_mod.cluster_registry, "_initialized", True)
     monkeypatch.setattr(reg_mod.cluster_registry, "_default_cluster", "default")
-    monkeypatch.setattr(reg_mod.cluster_registry, "_pve_clients", {"default": mock_proxmox})
-    monkeypatch.setattr(reg_mod.cluster_registry, "_pbs_clients", {"default": mock_proxmox})
+    monkeypatch.setattr(reg_mod.cluster_registry, "_pve_clients", {"default": test_proxmox})
+    monkeypatch.setattr(reg_mod.cluster_registry, "_pbs_clients", {"default": test_proxmox})
     monkeypatch.setattr(
         reg_mod.cluster_registry,
         "_configs",
@@ -558,7 +589,20 @@ async def client(db_session: AsyncSession, monkeypatch) -> AsyncGenerator[AsyncC
     # Patch volumes router so it uses the mock Proxmox client
     import app.routers.volumes as vol_mod
 
-    monkeypatch.setattr(vol_mod, "_get_proxmox", lambda cluster_id="default": mock_proxmox)
+    monkeypatch.setattr(vol_mod, "_get_proxmox", lambda cluster_id="default": test_proxmox)
+
+    # Flush Redis cache between tests so cached PVE responses from prior tests
+    # (e.g. an empty cluster_resources list) don't leak into this test.
+    try:
+        import redis.asyncio as _redis_async
+
+        _r = _redis_async.from_url("redis://localhost:6379/0", decode_responses=True)
+        _keys = await _r.keys("paws:cache:*")
+        if _keys:
+            await _r.delete(*_keys)
+        await _r.aclose()
+    except Exception:
+        pass
 
     from app.main import app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2290,14 +2290,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/bail": {
@@ -2331,9 +2331,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3228,16 +3228,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5110,9 +5110,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5123,9 +5123,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -5172,10 +5172,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5934,9 +5937,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -109,7 +109,7 @@ const ADMIN_SECTIONS = [
   },
   {
     label: 'Infrastructure',
-    tabs: ['Storage', 'Connections', 'SDN'] as const,
+    tabs: ['Storage', 'Connections', 'SDN', 'Drift'] as const,
   },
 ] as const;
 
@@ -213,6 +213,7 @@ export default function Admin() {
       {activeTab === 'API Keys' && <ApiKeysTab onSwitchTab={handleTabClick} />}
       {activeTab === 'Connections' && <ConnectionsTab />}
       {activeTab === 'SDN' && <SDNTab />}
+      {activeTab === 'Drift' && <DriftTab />}
     </div>
   );
 }
@@ -3251,7 +3252,7 @@ function ConnectionsTab() {
           {form.conn_type === 'pve' && (
             <>
               <div className="border-t border-paws-border-subtle pt-3 mt-1">
-                <p className="text-xs text-paws-text-dim mb-2">Console Access (xterm.js) — dedicated read-only Proxmox user for terminal sessions</p>
+                <p className="text-xs text-paws-text-dim mb-2">Console Access (xterm.js) - dedicated read-only Proxmox user for terminal sessions</p>
                 <Input label="Console Username" value={form.console_user} onChange={e => setForm(p => ({ ...p, console_user: e.target.value }))} placeholder="e.g. paws-console@pve" />
                 <Input label="Console Password" type="password" value={form.console_password} onChange={e => setForm(p => ({ ...p, console_password: e.target.value }))} placeholder={editing ? '(leave blank to keep current)' : ''} />
               </div>
@@ -3404,14 +3405,13 @@ function ClusterDetailView({ clusterId }: { clusterId: string }) {
   const { confirm } = useConfirm();
 
   const fetchStatus = () => {
-    api.get(`/api/cluster/status?cluster_id=${encodeURIComponent(clusterId)}`).then(r => setStatus(r.data)).catch(() => {});
+    api.get('/api/cluster/status').then(r => setStatus(r.data)).catch(() => {});
   };
 
   const fetchTasks = () => {
     setTasksLoading(true);
     const params = new URLSearchParams();
     params.set('limit', '200');
-    params.set('cluster_id', clusterId);
     if (nodeFilter) params.set('node', nodeFilter);
     if (typeFilter) params.set('type', typeFilter);
     if (errorsOnly) params.set('errors_only', 'true');
@@ -3486,7 +3486,7 @@ function ClusterDetailView({ clusterId }: { clusterId: string }) {
   const openTaskDetail = (task: PveTask) => {
     setDetailLoading(true);
     setSelectedTask(null);
-    api.get(`/api/cluster/admin/tasks/${encodeURIComponent(task.node)}/${encodeURIComponent(task.upid)}?cluster_id=${encodeURIComponent(clusterId)}`)
+    api.get(`/api/cluster/admin/tasks/${encodeURIComponent(task.node)}/${encodeURIComponent(task.upid)}`)
       .then(r => setSelectedTask(r.data))
       .catch(() => setSelectedTask({ ...task, exitstatus: 'fetch error', log: 'Failed to load task log.' }))
       .finally(() => setDetailLoading(false));
@@ -3808,6 +3808,159 @@ function ClusterDetailView({ clusterId }: { clusterId: string }) {
           </div>
         ) : null}
       </Modal>
+    </div>
+  );
+}
+
+// --- Drift Tab -----------------------------------------------------------
+
+function DriftTab() {
+  const [events, setEvents] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<'all' | 'active' | 'acknowledged'>('active');
+  const { toast } = useToast();
+  const { confirm } = useConfirm();
+
+  const fetchEvents = () => {
+    setLoading(true);
+    const params = filter === 'all' ? '' : filter === 'active' ? '?acknowledged=false' : '?acknowledged=true';
+    api.get(`/api/admin/drift${params}`)
+      .then(r => setEvents(r.data))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { fetchEvents(); }, [filter]);
+
+  const acknowledge = async (id: string) => {
+    try {
+      await api.post(`/api/admin/drift/${id}/acknowledge`);
+      toast('Event acknowledged', 'success');
+      fetchEvents();
+    } catch {
+      toast('Failed to acknowledge', 'error');
+    }
+  };
+
+  const fixEvent = async (id: string) => {
+    try {
+      const r = await api.post(`/api/admin/drift/${id}/fix`);
+      const changes = r.data?.changes ? Object.keys(r.data.changes).join(', ') : '';
+      toast(`Fixed${changes ? `: ${changes}` : ''}`, 'success');
+      fetchEvents();
+    } catch (e: any) {
+      toast(e?.response?.data?.detail ?? 'Failed to fix', 'error');
+    }
+  };
+
+  const fixAll = async () => {
+    if (!await confirm({ title: 'Fix All', message: 'Sync DB to Proxmox state for every auto-fixable drift event?' })) return;
+    try {
+      const r = await api.post('/api/admin/drift/fix-all');
+      toast(`Fixed ${r.data?.fixed ?? 0} event(s)`, 'success');
+      fetchEvents();
+    } catch {
+      toast('Failed to fix all', 'error');
+    }
+  };
+
+  const deleteEvent = async (id: string) => {
+    if (!await confirm({ title: 'Delete Event', message: 'Delete this drift event?' })) return;
+    try {
+      await api.delete(`/api/admin/drift/${id}`);
+      toast('Event deleted', 'success');
+      fetchEvents();
+    } catch {
+      toast('Failed to delete', 'error');
+    }
+  };
+
+  const DRIFT_LABELS: Record<string, string> = {
+    orphaned_in_db: 'Orphaned in DB',
+    orphaned_in_proxmox: 'Orphaned in Proxmox',
+    status_mismatch: 'Status Mismatch',
+    node_mismatch: 'Node Mismatch',
+  };
+
+  const DRIFT_COLOR: Record<string, string> = {
+    orphaned_in_db: 'text-red-400',
+    orphaned_in_proxmox: 'text-orange-400',
+    status_mismatch: 'text-yellow-400',
+    node_mismatch: 'text-blue-400',
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">Drift Events</h3>
+          <p className="text-sm text-muted-foreground">Divergence between PAWS database and Proxmox cluster state.</p>
+        </div>
+        <div className="flex gap-2">
+          <select
+            value={filter}
+            onChange={e => setFilter(e.target.value as any)}
+            className="text-sm border rounded px-2 py-1 bg-background"
+          >
+            <option value="active">Active</option>
+            <option value="acknowledged">Acknowledged</option>
+            <option value="all">All</option>
+          </select>
+          <Button variant="outline" size="sm" onClick={fetchEvents}>Refresh</Button>
+          <Button variant="success" size="sm" onClick={fixAll} disabled={!events.some(e => e.auto_fixable && !e.acknowledged)}>Fix All</Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-8 text-muted-foreground">Loading...</div>
+      ) : events.length === 0 ? (
+        <div className="text-center py-8 text-muted-foreground">
+          {filter === 'active' ? 'No active drift detected.' : 'No events found.'}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-left">
+            <thead>
+              <tr className="border-b text-muted-foreground">
+                <th className="pb-2 pr-4">Type</th>
+                <th className="pb-2 pr-4">Resource</th>
+                <th className="pb-2 pr-4">VMID</th>
+                <th className="pb-2 pr-4">Node</th>
+                <th className="pb-2 pr-4">Details</th>
+                <th className="pb-2 pr-4">Detected</th>
+                <th className="pb-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map(ev => (
+                <tr key={ev.id} className="border-b hover:bg-muted/50">
+                  <td className={`py-2 pr-4 font-medium ${DRIFT_COLOR[ev.drift_type] ?? ''}`}>
+                    {DRIFT_LABELS[ev.drift_type] ?? ev.drift_type}
+                  </td>
+                  <td className="py-2 pr-4 font-mono text-xs">{ev.resource_name ?? ev.resource_id ?? '-'}</td>
+                  <td className="py-2 pr-4">{ev.proxmox_vmid ?? '-'}</td>
+                  <td className="py-2 pr-4">{ev.proxmox_node ?? '-'}</td>
+                  <td className="py-2 pr-4 text-xs text-muted-foreground max-w-xs truncate">{ev.details ?? '-'}</td>
+                  <td className="py-2 pr-4 text-xs text-muted-foreground">
+                    {ev.detected_at ? new Date(ev.detected_at).toLocaleString() : '-'}
+                  </td>
+                  <td className="py-2">
+                    <div className="flex gap-1">
+                      {ev.auto_fixable && !ev.acknowledged && (
+                        <Button variant="success" size="sm" onClick={() => fixEvent(ev.id)}>Fix</Button>
+                      )}
+                      {!ev.acknowledged && (
+                        <Button variant="outline" size="sm" onClick={() => acknowledge(ev.id)}>Ack</Button>
+                      )}
+                      <Button variant="ghost" size="sm" onClick={() => deleteEvent(ev.id)}>Delete</Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/BackupsEnhanced.tsx
+++ b/frontend/src/pages/BackupsEnhanced.tsx
@@ -288,7 +288,7 @@ export default function BackupsEnhanced() {
       const url = window.URL.createObjectURL(new Blob([r.data]));
       const a = document.createElement('a');
       a.href = url;
-      const contentType = r.headers?.['content-type'] || '';
+      const contentType = String(r.headers?.['content-type'] || '');
       const isZip = contentType.includes('zip') || (!baseName.includes('.') && r.data.size > 0);
       a.download = isZip && !baseName.endsWith('.zip') ? `${baseName}.zip` : baseName;
       a.click();

--- a/frontend/src/pages/CreateInstance.tsx
+++ b/frontend/src/pages/CreateInstance.tsx
@@ -41,7 +41,6 @@ export default function CreateInstance() {
   const [vpcs, setVpcs] = useState<Array<{ id: string; name: string; cidr: string; network_mode?: string }>>([]);
   const [sshKeys, setSshKeys] = useState<Array<{ id: string; name: string }>>([]);
   const [storagePools, setStoragePools] = useState<string[]>([]);
-  const [clusters, setClusters] = useState<Array<{ name: string }>>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
@@ -53,7 +52,6 @@ export default function CreateInstance() {
     template_vmid: 0,
     selectedTemplate: null as Template | null,
     instance_type: '',
-    cluster_id: '',
     cores: 2,
     memory_mb: 2048,
     disk_gb: 32,
@@ -95,12 +93,6 @@ export default function CreateInstance() {
       setVpcs(data);
     }).catch(() => {});
     api.get('/api/ssh-keys/').then((res) => setSshKeys(res.data)).catch(() => {});
-    api.get('/api/cluster/list').then((res) => {
-      setClusters(res.data);
-      if (res.data.length === 1) {
-        setForm((prev) => ({ ...prev, cluster_id: res.data[0].name }));
-      }
-    }).catch(() => {});
     api.get('/api/storage-pools/').then((res) => {
       setStoragePools(res.data.pools || []);
       if (res.data.default) {
@@ -149,7 +141,6 @@ export default function CreateInstance() {
         memory_mb: form.memory_mb,
         disk_gb: form.disk_gb,
         storage: form.storage,
-        cluster_id: form.cluster_id || undefined,
         vpc_id: form.vpc_id || undefined,
         hostname: form.hostname || undefined,
         ssh_key_ids: form.ssh_key_ids.length > 0 ? form.ssh_key_ids : undefined,
@@ -293,7 +284,7 @@ export default function CreateInstance() {
           <Select
             label="VPC"
             placeholder="Select a VPC (optional)"
-            options={[{ value: '', label: 'No VPC' }, ...vpcs.map((v) => ({ value: v.id, label: `${v.name} (${v.cidr}) — ${(v.network_mode || 'private').charAt(0).toUpperCase() + (v.network_mode || 'private').slice(1)}` }))]}
+            options={[{ value: '', label: 'No VPC' }, ...vpcs.map((v) => ({ value: v.id, label: `${v.name} (${v.cidr}) - ${(v.network_mode || 'private').charAt(0).toUpperCase() + (v.network_mode || 'private').slice(1)}` }))]}
             value={form.vpc_id}
             onChange={(e) => setForm({ ...form, vpc_id: e.target.value })}
           />
@@ -308,11 +299,6 @@ export default function CreateInstance() {
         <div className="space-y-4">
           <Input label="Instance Name" value={form.name} placeholder="my-instance"
             onChange={(e) => setForm({ ...form, name: e.target.value })} />
-          {clusters.length > 1 && (
-            <Select label="Cluster" value={form.cluster_id}
-              options={clusters.map((c) => ({ value: c.name, label: c.name }))}
-              onChange={(e) => setForm({ ...form, cluster_id: e.target.value })} />
-          )}
           <Input label="Hostname" value={form.hostname} placeholder="Optional hostname"
             onChange={(e) => setForm({ ...form, hostname: e.target.value })} />
           <div className="grid grid-cols-2 gap-4">
@@ -359,7 +345,6 @@ export default function CreateInstance() {
           <CardContent className="space-y-3">
             <ReviewRow label="Template" value={form.selectedTemplate?.name || '-'} />
             <ReviewRow label="Name" value={form.name} />
-            {clusters.length > 1 && <ReviewRow label="Cluster" value={form.cluster_id || 'Default'} />}
             <ReviewRow label="Size" value={`${form.cores} vCPU · ${form.memory_mb} MB RAM · ${form.disk_gb} GB Disk`} />
             <ReviewRow label="Storage" value={form.storage} />
             <ReviewRow label="VPC" value={(() => { const v = vpcs.find((v) => v.id === form.vpc_id); return v ? `${v.name} (${(v.network_mode || 'private').charAt(0).toUpperCase() + (v.network_mode || 'private').slice(1)})` : 'None'; })()} />

--- a/frontend/src/pages/InstanceDetail.tsx
+++ b/frontend/src/pages/InstanceDetail.tsx
@@ -617,7 +617,7 @@ export default function InstanceDetail() {
       const url = window.URL.createObjectURL(new Blob([r.data]));
       const a = document.createElement('a');
       a.href = url;
-      const contentType = r.headers?.['content-type'] || '';
+      const contentType = String(r.headers?.['content-type'] || '');
       const isZip = contentType.includes('zip') || (!baseName.includes('.') && r.data.size > 0);
       a.download = isZip && !baseName.endsWith('.zip') ? `${baseName}.zip` : baseName;
       a.click();
@@ -913,9 +913,6 @@ export default function InstanceDetail() {
                 <Stat label="Created" value={new Date(inst.created_at).toLocaleString()} />
                 <Stat label="VMID" value={String(inst.proxmox_vmid)} />
                 <Stat label="Node" value={inst.proxmox_node} />
-                {inst.cluster_id && inst.cluster_id !== 'default' && (
-                  <Stat label="Cluster" value={inst.cluster_id} />
-                )}
               </div>
             </CardContent>
           </Card>

--- a/frontend/src/pages/SecurityGroups.tsx
+++ b/frontend/src/pages/SecurityGroups.tsx
@@ -35,8 +35,7 @@ export default function SecurityGroups() {
   const [showCreate, setShowCreate] = useState(false);
   const [selected, setSelected] = useState<SecurityGroup | null>(null);
   const [showAddRule, setShowAddRule] = useState(false);
-  const [clusters, setClusters] = useState<{name: string}[]>([]);
-  const [form, setForm] = useState({ name: '', description: '', cluster_id: '' });
+  const [form, setForm] = useState({ name: '', description: '' });
   const [ruleForm, setRuleForm] = useState<Rule>({
     direction: 'inbound', action: 'allow', protocol: 'tcp', port_range: '', source: '0.0.0.0/0',
   });
@@ -56,21 +55,12 @@ export default function SecurityGroups() {
 
   useEffect(fetchGroups, []);
 
-  useEffect(() => {
-    api.get('/api/cluster/list').then((res) => {
-      setClusters(res.data || []);
-      if (res.data?.length === 1) {
-        setForm((prev) => ({ ...prev, cluster_id: res.data![0].name }));
-      }
-    }).catch(() => {});
-  }, []);
-
   const handleCreate = async () => {
     try {
-      await api.post('/api/security-groups/', { ...form, cluster_id: form.cluster_id || undefined });
+      await api.post('/api/security-groups/', { ...form });
       toast('Firewall group created', 'success');
       setShowCreate(false);
-      setForm({ name: '', description: '', cluster_id: clusters.length === 1 ? clusters[0]?.name ?? '' : '' });
+      setForm({ name: '', description: '' });
       fetchGroups();
     } catch (e: any) {
       toast(e?.response?.data?.detail || 'Failed to create firewall group', 'error');
@@ -170,7 +160,6 @@ export default function SecurityGroups() {
                       <p className="text-xs text-paws-text-dim">{g.rules?.length || 0} rules</p>
                     </div>
                     <div className="flex items-center gap-1">
-                    {clusters.length > 1 && g.cluster_id && <Badge variant="default">{g.cluster_id}</Badge>}
                     {g.is_default && <Badge variant="info">Default</Badge>}
                     {!g.is_default && (
                       <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); handleDelete(g.id); }}>
@@ -221,11 +210,6 @@ export default function SecurityGroups() {
         <div className="space-y-4">
           <Input label="Name" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
           <Input label="Description" value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} />
-          {clusters.length > 1 && (
-            <Select label="Cluster" value={form.cluster_id}
-              options={clusters.map((c) => ({ value: c.name, label: c.name }))}
-              onChange={(e) => setForm({ ...form, cluster_id: e.target.value })} />
-          )}
           <div className="flex justify-end gap-2 pt-2">
             <Button variant="outline" onClick={() => setShowCreate(false)}>Cancel</Button>
             <Button onClick={handleCreate} disabled={!form.name}>Create</Button>

--- a/frontend/src/pages/VPCs.tsx
+++ b/frontend/src/pages/VPCs.tsx
@@ -3,7 +3,7 @@ import { Network, Plus, Trash2, Server, Globe, Edit2, Shield } from 'lucide-reac
 import api from '../api/client';
 import {
   Button, Card, CardHeader, CardTitle, CardContent,
-  Input, Modal, Badge, EmptyState, StatusBadge, Select,
+  Input, Modal, Badge, EmptyState, StatusBadge,
   useToast, useConfirm,
 } from '@/components/ui';
 import { cn } from '@/lib/utils';
@@ -61,8 +61,7 @@ export default function VPCs() {
   const [selected, setSelected] = useState<VPC | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [instances, setInstances] = useState<VPCInstance[]>([]);
-  const [clusters, setClusters] = useState<{name: string}[]>([]);
-  const [form, setForm] = useState({ name: '', network_mode: 'private', cluster_id: '' });
+  const [form, setForm] = useState({ name: '', network_mode: 'private' });
   const [changingMode, setChangingMode] = useState(false);
   const [editIpInst, setEditIpInst] = useState<VPCInstance | null>(null);
   const [newIp, setNewIp] = useState('');
@@ -83,15 +82,6 @@ export default function VPCs() {
   useEffect(fetchVPCs, []);
 
   useEffect(() => {
-    api.get('/api/cluster/list').then((res) => {
-      setClusters(res.data || []);
-      if (res.data?.length === 1) {
-        setForm((prev) => ({ ...prev, cluster_id: res.data![0].name }));
-      }
-    }).catch(() => {});
-  }, []);
-
-  useEffect(() => {
     if (selected) {
       api.get(`/api/vpcs/${selected.id}/instances`).then((res) => setInstances(res.data)).catch(() => setInstances([]));
     }
@@ -99,9 +89,9 @@ export default function VPCs() {
 
   const handleCreate = async () => {
     try {
-      await api.post('/api/vpcs/', { name: form.name, network_mode: form.network_mode, cluster_id: form.cluster_id || undefined });
+      await api.post('/api/vpcs/', { name: form.name, network_mode: form.network_mode });
       setShowCreate(false);
-      setForm({ name: '', network_mode: 'private', cluster_id: clusters.length === 1 ? clusters[0]?.name ?? '' : '' });
+      setForm({ name: '', network_mode: 'private' });
       fetchVPCs();
     } catch (e: any) {
       toast(e?.response?.data?.detail || 'Failed to create network', 'error');
@@ -169,7 +159,6 @@ export default function VPCs() {
                         {(vpc.network_mode || 'private').charAt(0).toUpperCase() + (vpc.network_mode || 'private').slice(1)}
                       </Badge>
                       <StatusBadge status={vpc.status} />
-                      {clusters.length > 1 && vpc.cluster_id && <Badge variant="default">{vpc.cluster_id}</Badge>}
                     </div>
                   </div>
                 </CardContent>
@@ -416,11 +405,6 @@ export default function VPCs() {
             </div>
           </div>
           <p className="text-xs text-paws-text-dim">CIDR will be auto-allocated. IPs are assigned statically to instances.</p>
-          {clusters.length > 1 && (
-            <Select label="Cluster" value={form.cluster_id}
-              options={clusters.map((c) => ({ value: c.name, label: c.name }))}
-              onChange={(e) => setForm({ ...form, cluster_id: e.target.value })} />
-          )}
           <div className="flex justify-end gap-2 pt-2">
             <Button variant="outline" onClick={() => setShowCreate(false)}>Cancel</Button>
             <Button onClick={handleCreate} disabled={!form.name}>Create</Button>

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# PAWS database backup script.
+#
+# Reads connection details from PAWS_DATABASE_URL (same env var the app uses).
+# Writes a gzip-compressed pg_dump to the target directory.
+#
+# Usage:
+#   ./scripts/backup-db.sh [output_dir]
+#
+# Examples:
+#   ./scripts/backup-db.sh                      # writes to ./backups/
+#   ./scripts/backup-db.sh /mnt/nas/paws-backups
+#   PAWS_DATABASE_URL=postgresql+asyncpg://u:p@host/db ./scripts/backup-db.sh
+#
+# The output filename is:  paws-db-YYYYMMDD-HHMMSS.sql.gz
+# Exit codes: 0 = success, 1 = error
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Default DB URL matches docker-compose default; override via env
+DB_URL="${PAWS_DATABASE_URL:-postgresql+asyncpg://paws:paws@localhost:5432/paws}"
+
+# Strip asyncpg dialect so psql/pg_dump accept the URL
+DB_URL="${DB_URL/postgresql+asyncpg/postgresql}"
+
+# Output directory (first arg or ./backups)
+OUTPUT_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)/backups}"
+
+# ---------------------------------------------------------------------------
+# Parse connection parameters from URL
+# postgresql://user:password@host:port/dbname
+# ---------------------------------------------------------------------------
+_strip_proto="${DB_URL#postgresql://}"
+DB_USER="${_strip_proto%%:*}"
+_after_user="${_strip_proto#*:}"
+DB_PASS="${_after_user%%@*}"
+_after_pass="${_after_user#*@}"
+DB_HOST="${_after_pass%%:*}"
+_after_host="${_after_pass#*:}"
+DB_PORT="${_after_host%%/*}"
+DB_NAME="${_after_host#*/}"
+# Remove any query string
+DB_NAME="${DB_NAME%%\?*}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+red()   { printf "\033[1;31m%s\033[0m\n" "$*" >&2; }
+green() { printf "\033[1;32m%s\033[0m\n" "$*"; }
+info()  { printf "[backup] %s\n" "$*"; }
+
+require_cmd() {
+    if ! command -v "$1" &>/dev/null; then
+        red "ERROR: '$1' not found. Install postgresql-client."
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+require_cmd pg_dump
+require_cmd gzip
+
+mkdir -p "$OUTPUT_DIR"
+
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+OUTFILE="${OUTPUT_DIR}/paws-db-${TIMESTAMP}.sql.gz"
+
+info "Host:     ${DB_HOST}:${DB_PORT}"
+info "Database: ${DB_NAME}"
+info "User:     ${DB_USER}"
+info "Output:   ${OUTFILE}"
+
+# ---------------------------------------------------------------------------
+# Dump
+# ---------------------------------------------------------------------------
+export PGPASSWORD="${DB_PASS}"
+
+if pg_dump \
+    --host="${DB_HOST}" \
+    --port="${DB_PORT}" \
+    --username="${DB_USER}" \
+    --dbname="${DB_NAME}" \
+    --format=plain \
+    --no-owner \
+    --no-acl \
+    | gzip > "${OUTFILE}"; then
+    SIZE="$(du -sh "${OUTFILE}" | cut -f1)"
+    green "Backup complete: ${OUTFILE} (${SIZE})"
+else
+    red "ERROR: pg_dump failed."
+    rm -f "${OUTFILE}"
+    exit 1
+fi

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# PAWS database restore script.
+#
+# Reads connection details from PAWS_DATABASE_URL (same env var the app uses).
+# Accepts a gzip-compressed or plain SQL backup file produced by backup-db.sh.
+#
+# Usage:
+#   ./scripts/restore-db.sh <backup_file>
+#
+# Examples:
+#   ./scripts/restore-db.sh backups/paws-db-20260421-120000.sql.gz
+#   ./scripts/restore-db.sh backups/paws-db-20260421-120000.sql
+#
+# WARNING: This will DROP all existing tables and restore from the backup.
+#          Stop the PAWS app before running to avoid in-flight transactions.
+#
+# Exit codes: 0 = success, 1 = error
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DB_URL="${PAWS_DATABASE_URL:-postgresql+asyncpg://paws:paws@localhost:5432/paws}"
+DB_URL="${DB_URL/postgresql+asyncpg/postgresql}"
+
+# ---------------------------------------------------------------------------
+# Parse connection parameters from URL
+# ---------------------------------------------------------------------------
+_strip_proto="${DB_URL#postgresql://}"
+DB_USER="${_strip_proto%%:*}"
+_after_user="${_strip_proto#*:}"
+DB_PASS="${_after_user%%@*}"
+_after_pass="${_after_user#*@}"
+DB_HOST="${_after_pass%%:*}"
+_after_host="${_after_pass#*:}"
+DB_PORT="${_after_host%%/*}"
+DB_NAME="${_after_host#*/}"
+DB_NAME="${DB_NAME%%\?*}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+red()    { printf "\033[1;31m%s\033[0m\n" "$*" >&2; }
+yellow() { printf "\033[1;33m%s\033[0m\n" "$*"; }
+green()  { printf "\033[1;32m%s\033[0m\n" "$*"; }
+info()   { printf "[restore] %s\n" "$*"; }
+
+require_cmd() {
+    if ! command -v "$1" &>/dev/null; then
+        red "ERROR: '$1' not found. Install postgresql-client."
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument check
+# ---------------------------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+    red "Usage: $0 <backup_file>"
+    red "  backup_file: path to .sql.gz or .sql backup produced by backup-db.sh"
+    exit 1
+fi
+
+BACKUP_FILE="$1"
+
+if [[ ! -f "${BACKUP_FILE}" ]]; then
+    red "ERROR: Backup file not found: ${BACKUP_FILE}"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+require_cmd psql
+require_cmd pg_dump
+
+if [[ "${BACKUP_FILE}" == *.gz ]]; then
+    require_cmd gunzip
+    COMPRESSED=true
+else
+    COMPRESSED=false
+fi
+
+# ---------------------------------------------------------------------------
+# Confirmation prompt
+# ---------------------------------------------------------------------------
+yellow "============================================================"
+yellow " WARNING: This will replace ALL data in '${DB_NAME}'."
+yellow " Host:     ${DB_HOST}:${DB_PORT}"
+yellow " Database: ${DB_NAME}"
+yellow " Backup:   ${BACKUP_FILE}"
+yellow "============================================================"
+printf "Type 'yes' to continue: "
+read -r CONFIRM
+if [[ "${CONFIRM}" != "yes" ]]; then
+    info "Aborted."
+    exit 0
+fi
+
+export PGPASSWORD="${DB_PASS}"
+
+PSQL_OPTS=(--host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USER}" --dbname="${DB_NAME}" --no-password)
+PSQL_ADMIN=(--host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USER}" --dbname="postgres" --no-password)
+
+# ---------------------------------------------------------------------------
+# Drop existing schema and recreate
+# ---------------------------------------------------------------------------
+info "Terminating existing connections to ${DB_NAME}..."
+psql "${PSQL_ADMIN[@]}" -c \
+    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${DB_NAME}' AND pid <> pg_backend_pid();" \
+    --quiet
+
+info "Dropping and recreating database ${DB_NAME}..."
+psql "${PSQL_ADMIN[@]}" -c "DROP DATABASE IF EXISTS \"${DB_NAME}\";" --quiet
+psql "${PSQL_ADMIN[@]}" -c "CREATE DATABASE \"${DB_NAME}\" OWNER \"${DB_USER}\";" --quiet
+
+# ---------------------------------------------------------------------------
+# Restore
+# ---------------------------------------------------------------------------
+info "Restoring from ${BACKUP_FILE}..."
+
+if $COMPRESSED; then
+    gunzip --stdout "${BACKUP_FILE}" | psql "${PSQL_OPTS[@]}" --quiet
+else
+    psql "${PSQL_OPTS[@]}" --quiet < "${BACKUP_FILE}"
+fi
+
+green "Restore complete. Database '${DB_NAME}' is ready."
+info "Run 'alembic upgrade head' if the backup pre-dates recent migrations."

--- a/scripts/test-db-backup-restore.sh
+++ b/scripts/test-db-backup-restore.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# PAWS DB backup/restore smoke test.
+#
+# Requires a running PostgreSQL instance (e.g. docker-compose up db).
+# Tests the full backup -> drop -> restore cycle and verifies row counts match.
+#
+# Usage:
+#   ./scripts/test-db-backup-restore.sh
+#
+# Set PAWS_DATABASE_URL to override the default connection.
+# Exit codes: 0 = passed, 1 = failed
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+DB_URL="${PAWS_DATABASE_URL:-postgresql+asyncpg://paws:paws@localhost:5432/paws}"
+DB_URL="${DB_URL/postgresql+asyncpg/postgresql}"
+
+_strip_proto="${DB_URL#postgresql://}"
+DB_USER="${_strip_proto%%:*}"
+_after_user="${_strip_proto#*:}"
+DB_PASS="${_after_user%%@*}"
+_after_pass="${_after_user#*@}"
+DB_HOST="${_after_pass%%:*}"
+_after_host="${_after_pass#*:}"
+DB_PORT="${_after_host%%/*}"
+DB_NAME="${_after_host#*/}"
+DB_NAME="${DB_NAME%%\?*}"
+
+export PGPASSWORD="${DB_PASS}"
+
+red()   { printf "\033[1;31m%s\033[0m\n" "$*" >&2; }
+green() { printf "\033[1;32m%s\033[0m\n" "$*"; }
+info()  { printf "[smoke] %s\n" "$*"; }
+
+PSQL=(psql --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USER}" --dbname="${DB_NAME}" --no-password --tuples-only --no-align --quiet)
+
+# ---------------------------------------------------------------------------
+# 1. Verify DB is reachable
+# ---------------------------------------------------------------------------
+info "Connecting to ${DB_HOST}:${DB_PORT}/${DB_NAME}..."
+if ! psql --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USER}" \
+          --dbname="${DB_NAME}" --no-password -c "SELECT 1;" &>/dev/null; then
+    red "ERROR: Cannot connect to database. Is docker-compose up?"
+    exit 1
+fi
+green "Connection OK."
+
+# ---------------------------------------------------------------------------
+# 2. Count rows before backup
+# ---------------------------------------------------------------------------
+info "Counting rows in key tables before backup..."
+USERS_BEFORE="$("${PSQL[@]}" -c "SELECT COUNT(*) FROM users;" 2>/dev/null | tr -d ' ' || echo 0)"
+RESOURCES_BEFORE="$("${PSQL[@]}" -c "SELECT COUNT(*) FROM resources;" 2>/dev/null | tr -d ' ' || echo 0)"
+info "  users:     ${USERS_BEFORE}"
+info "  resources: ${RESOURCES_BEFORE}"
+
+# ---------------------------------------------------------------------------
+# 3. Backup
+# ---------------------------------------------------------------------------
+BACKUP_DIR="$(mktemp -d)"
+trap 'rm -rf "${BACKUP_DIR}"' EXIT
+
+info "Running backup-db.sh -> ${BACKUP_DIR}..."
+PAWS_DATABASE_URL="${PAWS_DATABASE_URL:-postgresql://paws:paws@localhost:5432/paws}" \
+    bash "${REPO_ROOT}/scripts/backup-db.sh" "${BACKUP_DIR}"
+
+BACKUP_FILE="$(ls "${BACKUP_DIR}"/paws-db-*.sql.gz | head -1)"
+if [[ -z "${BACKUP_FILE}" ]]; then
+    red "ERROR: No backup file produced."
+    exit 1
+fi
+green "Backup produced: $(basename "${BACKUP_FILE}")"
+
+# ---------------------------------------------------------------------------
+# 4. Drop all tables (simulate data loss without dropping the DB)
+# ---------------------------------------------------------------------------
+info "Dropping all tables to simulate data loss..."
+PSQL_QUIET=(psql --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USER}" --dbname="${DB_NAME}" --no-password --quiet)
+"${PSQL_QUIET[@]}" -c "
+DO \$\$ DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') LOOP
+        EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(r.tablename) || ' CASCADE';
+    END LOOP;
+END \$\$;
+"
+TABLES_AFTER_DROP="$("${PSQL_QUIET[@]}" --tuples-only --no-align -c \
+    "SELECT COUNT(*) FROM pg_tables WHERE schemaname='public';" 2>/dev/null | tr -d ' ' || echo 0)"
+info "Tables remaining after drop: ${TABLES_AFTER_DROP}"
+if [[ "${TABLES_AFTER_DROP}" -ne 0 ]]; then
+    red "ERROR: Tables still exist after drop. Cannot validate restore."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Restore via restore-db.sh (non-interactive: pipe 'yes')
+# ---------------------------------------------------------------------------
+info "Running restore-db.sh with backup ${BACKUP_FILE}..."
+echo "yes" | PAWS_DATABASE_URL="${PAWS_DATABASE_URL:-postgresql://paws:paws@localhost:5432/paws}" \
+    bash "${REPO_ROOT}/scripts/restore-db.sh" "${BACKUP_FILE}"
+
+# ---------------------------------------------------------------------------
+# 6. Verify row counts match
+# ---------------------------------------------------------------------------
+info "Verifying row counts after restore..."
+USERS_AFTER="$("${PSQL[@]}" -c "SELECT COUNT(*) FROM users;" 2>/dev/null | tr -d ' ' || echo -1)"
+RESOURCES_AFTER="$("${PSQL[@]}" -c "SELECT COUNT(*) FROM resources;" 2>/dev/null | tr -d ' ' || echo -1)"
+info "  users:     ${USERS_AFTER} (expected ${USERS_BEFORE})"
+info "  resources: ${RESOURCES_AFTER} (expected ${RESOURCES_BEFORE})"
+
+FAIL=0
+if [[ "${USERS_AFTER}" != "${USERS_BEFORE}" ]]; then
+    red "FAIL: users row count mismatch (${USERS_BEFORE} -> ${USERS_AFTER})"
+    FAIL=1
+fi
+if [[ "${RESOURCES_AFTER}" != "${RESOURCES_BEFORE}" ]]; then
+    red "FAIL: resources row count mismatch (${RESOURCES_BEFORE} -> ${RESOURCES_AFTER})"
+    FAIL=1
+fi
+
+if [[ $FAIL -eq 0 ]]; then
+    green "Smoke test passed: backup/restore cycle verified."
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
### Added
- Added scripts/backup-db.sh for gzip-compressed pg_dump backups with auto-parsed DATABASE_URL.
- Added scripts/restore-db.sh for confirmed drop-and-restore with connection termination.
- Added scripts/test-db-backup-restore.sh smoke test validating the full backup/restore cycle.
- Added .InternalDocs/db-backup-restore-runbook.md covering all recovery scenarios.
- **Drift** - Added `POST /api/admin/drift/{event_id}/fix` and `POST /api/admin/drift/fix-all` to immediately reconcile auto-fixable drift events without waiting for the next scan.
- **Drift UI** - Added per-row Fix and toolbar Fix All buttons to the Admin > Drift tab; events expose an `auto_fixable` flag so the UI can disable buttons for non-fixable types.
- **Backups** - Added 15-second Redis cache for snapshot listings with invalidation on create, rollback, and delete to cut PVE round-trips on the backup pages.
- **Proxmox cache helpers** - Added `app/services/proxmox_cache.py` with reusable cached PVE call primitives shared across routers.

### Changed
- **Drift scanner** - `status_mismatch` and `node_mismatch` are now auto-corrected against PVE during the scheduled scan (PVE is treated as source of truth); these no longer raise drift events.
- **Network migration** - Rewrote `PUT /api/compute/vms/{id}/network` to be transactionally consistent: target VPC IP is allocated first, the instance is stopped, PVE config is updated atomically (single call for VMs with cloud-init regen, single call for LXC), then DB is committed and the instance restarted; on any failure the previous PVE config and DB state are restored. Restricted to `net0` so primary-VPC reservation logic stays coherent.
- **Backups** - All snapshot operations (list, create, rollback, delete) now run via `asyncio.to_thread` so the event loop is no longer blocked on PVE API calls.
- **Celery tasks** - `email_tasks`, `resource_lifecycle`, and `drift_scanner` now run their async bodies through a shared `app/tasks/_async_runner.py` helper that builds a fresh per-task engine; eliminates the recurring "Future attached to a different loop" errors under Celery prefork.
- **Cluster status cache** - `refresh_cluster_status_cache` now refreshes a single primary key instead of iterating registered clusters, matching the single-cluster deployment model.

### Fixed
- **IP reservations** - Network migration no longer drops the old reservation before confirming the target VPC has an allocatable IP; returns 409 if no IP is available, preventing the "DB has no IP, PVE keeps stale ipconfig0" drift.
- **Secondary NIC reservations** - Old IP reservation cleanup is now scoped to the old VPC subnets and the primary NIC label, so secondary-NIC reservations are no longer wiped during a primary network change.